### PR TITLE
feat(sink): Sink interface + HTTP sink + mock

### DIFF
--- a/internal/outbox/sinks/http.go
+++ b/internal/outbox/sinks/http.go
@@ -1,0 +1,194 @@
+package sinks
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// HTTPSink delivers messages via HTTP POST. It classifies failures into
+// retryable (408 / 425 / 429 / 5xx + network errors) and terminal
+// (everything else, including malformed destinations and 3xx); the
+// dispatcher (#6) owns the retry policy and surfaces metrics.
+type HTTPSink struct {
+	client *http.Client
+}
+
+// HTTPSinkOption configures an HTTPSink.
+type HTTPSinkOption func(*HTTPSink)
+
+// Bounds applied while reading response bodies — cap memory for both
+// keepalive draining and error-context snippets.
+const (
+	maxResponseBytes = 64 * 1024 // hard cap on body read; bigger responses end the connection
+	maxErrSnippet    = 512       // first N bytes included in terminal/retryable error strings
+)
+
+// NewHTTPSink returns an HTTPSink with sensible production defaults:
+// 30-second per-request timeout; transport cloned from http.DefaultTransport
+// (so TLSHandshakeTimeout, ExpectContinueTimeout, dial keepalive remain
+// in place) with pool fields tuned for low-cardinality destination sets;
+// redirects disabled — a 3xx response is surfaced as terminal, since
+// silently re-POSTing the Idempotency-Key to a different host would
+// surprise operators.
+//
+// Override the client via WithHTTPClient for tests or for tuning at
+// the application level.
+func NewHTTPSink(opts ...HTTPSinkOption) *HTTPSink {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConns = 100
+	transport.MaxConnsPerHost = 10
+	transport.MaxIdleConnsPerHost = 10
+	transport.IdleConnTimeout = 90 * time.Second
+
+	s := &HTTPSink{
+		client: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: transport,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// WithHTTPClient overrides the default *http.Client. Tests use this to
+// route through httptest.Server; production callers use it to share a
+// pre-configured outer client.
+func WithHTTPClient(c *http.Client) HTTPSinkOption {
+	return func(s *HTTPSink) { s.client = c }
+}
+
+// Name returns SinkHTTP.
+func (s *HTTPSink) Name() string { return SinkHTTP }
+
+// reservedHTTPHeaders are owned by the sink and cannot be set via
+// Message.Headers. Stored in canonical form for case-insensitive lookup
+// against http.CanonicalHeaderKey-normalized user input.
+var reservedHTTPHeaders = map[string]struct{}{
+	http.CanonicalHeaderKey("Content-Type"):    {},
+	http.CanonicalHeaderKey("Idempotency-Key"): {},
+	http.CanonicalHeaderKey("Traceparent"):     {},
+	http.CanonicalHeaderKey("Tracestate"):      {},
+}
+
+// Send POSTs msg.Payload to msg.Destination as application/json. Returns
+// nil on 2xx, *RetryableError on 408/425/429/5xx + network errors (with
+// Retry-After surfaced when the server provides one), ctx.Err on caller
+// cancellation, or a terminal error on malformed input / 3xx / 4xx.
+func (s *HTTPSink) Send(ctx context.Context, msg Message) error {
+	if msg.Destination == "" {
+		return errors.New("destination required")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, msg.Destination, bytes.NewReader(msg.Payload))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+
+	// Reserved headers — set first so user headers can't reach them.
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", strconv.FormatInt(msg.ID, 10))
+	if msg.Traceparent != "" {
+		req.Header.Set("traceparent", msg.Traceparent)
+	}
+	if msg.Tracestate != "" {
+		req.Header.Set("tracestate", msg.Tracestate)
+	}
+
+	for k, v := range msg.Headers {
+		if _, isReserved := reservedHTTPHeaders[http.CanonicalHeaderKey(k)]; isReserved {
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		// Caller-canceled context: propagate as ctx.Err so the dispatcher
+		// can distinguish shutdown from a transient transport problem.
+		if errors.Is(err, context.Canceled) {
+			return ctx.Err()
+		}
+		// All other transport errors (DNS, refused, timeout, conn reset)
+		// are transient; the dispatcher applies its own backoff.
+		return NewRetryableError(fmt.Errorf("http do: %w", err), 0)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+
+	if isSuccess(resp.StatusCode) {
+		return nil
+	}
+
+	if isRetryableStatus(resp.StatusCode) {
+		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+		return NewRetryableError(formatHTTPError(resp.StatusCode, body), retryAfter)
+	}
+
+	return formatHTTPError(resp.StatusCode, body)
+}
+
+// formatHTTPError builds an error containing the status code, reason
+// phrase, and a bounded body snippet to give operators something useful
+// in logs and dead-letter inspection.
+func formatHTTPError(code int, body []byte) error {
+	snippet := bytes.TrimSpace(body)
+	if len(snippet) > maxErrSnippet {
+		snippet = snippet[:maxErrSnippet]
+	}
+	if len(snippet) == 0 {
+		return fmt.Errorf("http %d %s", code, http.StatusText(code))
+	}
+	return fmt.Errorf("http %d %s: %s", code, http.StatusText(code), snippet)
+}
+
+func isSuccess(status int) bool { return status >= 200 && status < 300 }
+
+// isRetryableStatus per the issue: 408, 425, 429, 5xx.
+func isRetryableStatus(status int) bool {
+	switch status {
+	case http.StatusRequestTimeout, // 408
+		http.StatusTooEarly,        // 425
+		http.StatusTooManyRequests: // 429
+		return true
+	}
+	return status >= 500 && status < 600
+}
+
+// parseRetryAfter returns the duration encoded in a Retry-After header.
+// Supports the two RFC 7231 forms: delta-seconds (e.g. "120") and
+// HTTP-date (e.g. "Wed, 21 Oct 2015 07:28:00 GMT"). Returns 0 for empty,
+// negative, past-dated, or unparseable values; the dispatcher then falls
+// back to its own exponential backoff.
+func parseRetryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(value); err == nil {
+		if seconds < 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	if t, err := http.ParseTime(value); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return 0
+}

--- a/internal/outbox/sinks/http_test.go
+++ b/internal/outbox/sinks/http_test.go
@@ -1,0 +1,386 @@
+package sinks_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ronango/pgrelay/internal/outbox/sinks"
+)
+
+func TestHTTPSink_Name(t *testing.T) {
+	if got := sinks.NewHTTPSink().Name(); got != sinks.SinkHTTP {
+		t.Errorf("Name() = %q, want %q", got, sinks.SinkHTTP)
+	}
+}
+
+func TestHTTPSink_PostsPayloadVerbatim(t *testing.T) {
+	const payload = `{"event":"order.created","total":"42.00"}`
+
+	var got struct {
+		method      string
+		path        string
+		body        string
+		contentType string
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got.method = r.Method
+		got.path = r.URL.Path
+		got.contentType = r.Header.Get("Content-Type")
+		b, _ := io.ReadAll(r.Body)
+		got.body = string(b)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+	err := sink.Send(t.Context(), sinks.Message{
+		ID:          42,
+		Destination: srv.URL + "/events",
+		Payload:     []byte(payload),
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if got.method != http.MethodPost {
+		t.Errorf("method = %s, want POST", got.method)
+	}
+	if got.path != "/events" {
+		t.Errorf("path = %s, want /events", got.path)
+	}
+	if got.body != payload {
+		t.Errorf("body = %q, want %q", got.body, payload)
+	}
+	if got.contentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got.contentType)
+	}
+}
+
+func TestHTTPSink_SetsReservedHeaders(t *testing.T) {
+	var seen http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+	err := sink.Send(t.Context(), sinks.Message{
+		ID:          12345,
+		Destination: srv.URL,
+		Payload:     []byte(`{}`),
+		Traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+		Tracestate:  "rojo=00f067aa0ba902b7",
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if got := seen.Get("Idempotency-Key"); got != "12345" {
+		t.Errorf("Idempotency-Key = %q, want 12345", got)
+	}
+	if got := seen.Get("Traceparent"); got != "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01" {
+		t.Errorf("Traceparent = %q", got)
+	}
+	if got := seen.Get("Tracestate"); got != "rojo=00f067aa0ba902b7" {
+		t.Errorf("Tracestate = %q", got)
+	}
+}
+
+func TestHTTPSink_UserHeadersCannotOverwriteReserved(t *testing.T) {
+	var seen http.Header
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+	err := sink.Send(t.Context(), sinks.Message{
+		ID:          1,
+		Destination: srv.URL,
+		Payload:     []byte(`{}`),
+		Traceparent: "tp-real",
+		Tracestate:  "ts-real",
+		Headers: map[string]string{
+			"content-type":     "text/plain",           // canonical-form variant
+			"IDEMPOTENCY-KEY":  "user-trying-to-spoof", // upper-case variant
+			"traceparent":      "tp-spoof",
+			"TRACESTATE":       "ts-spoof",
+			"X-Custom-Header":  "kept",
+			"X-Another-Header": "kept-too",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	// Reserved still set by sink.
+	if got := seen.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, user header leaked through", got)
+	}
+	if got := seen.Get("Idempotency-Key"); got != "1" {
+		t.Errorf("Idempotency-Key = %q, user header leaked through", got)
+	}
+	if got := seen.Get("Traceparent"); got != "tp-real" {
+		t.Errorf("Traceparent = %q, user header leaked through", got)
+	}
+	if got := seen.Get("Tracestate"); got != "ts-real" {
+		t.Errorf("Tracestate = %q, user header leaked through", got)
+	}
+	// Custom user headers passed through unchanged.
+	if got := seen.Get("X-Custom-Header"); got != "kept" {
+		t.Errorf("X-Custom-Header = %q, want kept", got)
+	}
+	if got := seen.Get("X-Another-Header"); got != "kept-too" {
+		t.Errorf("X-Another-Header = %q, want kept-too", got)
+	}
+}
+
+func TestHTTPSink_SuccessStatusCodes(t *testing.T) {
+	for _, code := range []int{200, 201, 202, 204} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			srv := newStatusServer(t, code, "", nil)
+			sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+			if err := sink.Send(t.Context(), msgFor(srv.URL)); err != nil {
+				t.Errorf("Send for %d returned %v, want nil", code, err)
+			}
+		})
+	}
+}
+
+func TestHTTPSink_RetryableStatusCodes(t *testing.T) {
+	for _, code := range []int{408, 425, 429, 500, 502, 503, 504} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			srv := newStatusServer(t, code, "", nil)
+			sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+
+			err := sink.Send(t.Context(), msgFor(srv.URL))
+			if !sinks.IsRetryable(err) {
+				t.Errorf("Send for %d returned %v, want *RetryableError", code, err)
+			}
+		})
+	}
+}
+
+func TestHTTPSink_TerminalStatusCodes(t *testing.T) {
+	for _, code := range []int{400, 401, 403, 404, 422, 451} {
+		t.Run(strconv.Itoa(code), func(t *testing.T) {
+			srv := newStatusServer(t, code, "", nil)
+			sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+
+			err := sink.Send(t.Context(), msgFor(srv.URL))
+			if err == nil {
+				t.Fatalf("Send for %d returned nil, want terminal error", code)
+			}
+			if sinks.IsRetryable(err) {
+				t.Errorf("Send for %d classified as retryable, want terminal", code)
+			}
+		})
+	}
+}
+
+func TestHTTPSink_3xxTerminal(t *testing.T) {
+	// CheckRedirect: ErrUseLastResponse — 3xx must surface as terminal.
+	// We rely on the sink's own client (which carries the CheckRedirect
+	// policy); httptest.NewServer is plain HTTP so the default transport
+	// reaches it without TLS gymnastics.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "http://elsewhere.example/")
+		w.WriteHeader(http.StatusMovedPermanently)
+	}))
+	t.Cleanup(srv.Close)
+
+	sink := sinks.NewHTTPSink()
+	err := sink.Send(t.Context(), msgFor(srv.URL))
+	if err == nil {
+		t.Fatal("Send returned nil for 301, want terminal")
+	}
+	if sinks.IsRetryable(err) {
+		t.Errorf("301 classified as retryable, want terminal: %v", err)
+	}
+}
+
+func TestHTTPSink_RetryAfterDeltaSeconds(t *testing.T) {
+	srv := newStatusServer(t, http.StatusTooManyRequests, "", http.Header{
+		"Retry-After": []string{"7"},
+	})
+	sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+
+	err := sink.Send(t.Context(), msgFor(srv.URL))
+	re, ok := sinks.AsRetryable(err)
+	if !ok {
+		t.Fatalf("Send returned %v, want *RetryableError", err)
+	}
+	if re.RetryAfter != 7*time.Second {
+		t.Errorf("RetryAfter = %s, want 7s", re.RetryAfter)
+	}
+}
+
+func TestHTTPSink_RetryAfterHTTPDate(t *testing.T) {
+	future := time.Now().Add(15 * time.Second).UTC().Format(http.TimeFormat)
+	srv := newStatusServer(t, http.StatusServiceUnavailable, "", http.Header{
+		"Retry-After": []string{future},
+	})
+	sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+
+	err := sink.Send(t.Context(), msgFor(srv.URL))
+	re, ok := sinks.AsRetryable(err)
+	if !ok {
+		t.Fatalf("Send returned %v, want *RetryableError", err)
+	}
+	// Tolerance: HTTP-date has 1-second resolution and parsing takes
+	// real time on slow CI; assert "tracks the encoded value" rather
+	// than a tight bound.
+	if re.RetryAfter < 10*time.Second || re.RetryAfter > 20*time.Second {
+		t.Errorf("RetryAfter = %s, want roughly 15s", re.RetryAfter)
+	}
+}
+
+func TestHTTPSink_RetryAfterAbsentOrUnparseable(t *testing.T) {
+	cases := []struct {
+		name string
+		set  bool // false = header omitted; true = set to value (incl. "")
+		val  string
+	}{
+		{name: "absent", set: false},
+		{name: "empty_string", set: true, val: ""},
+		{name: "garbage", set: true, val: "soon"},
+		{name: "past_date", set: true, val: time.Now().Add(-1 * time.Hour).UTC().Format(http.TimeFormat)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			if tc.set {
+				h["Retry-After"] = []string{tc.val}
+			}
+			srv := newStatusServer(t, http.StatusServiceUnavailable, "", h)
+			sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+
+			re, ok := sinks.AsRetryable(sink.Send(t.Context(), msgFor(srv.URL)))
+			if !ok {
+				t.Fatal("expected *RetryableError")
+			}
+			if re.RetryAfter != 0 {
+				t.Errorf("RetryAfter = %s, want 0", re.RetryAfter)
+			}
+		})
+	}
+}
+
+func TestHTTPSink_NetworkErrorRetryable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Close() // close before sending so connect refuses
+
+	sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+	err := sink.Send(t.Context(), msgFor(srv.URL))
+	if !sinks.IsRetryable(err) {
+		t.Errorf("network error not classified as retryable: %v", err)
+	}
+}
+
+func TestHTTPSink_ContextCanceledIsTerminal(t *testing.T) {
+	// Pre-canceled ctx — http.NewRequestWithContext succeeds (it doesn't
+	// inspect ctx state); client.Do is the call that surfaces the ctx
+	// error, which exercises the `errors.Is(err, context.Canceled)`
+	// branch in Send and returns ctx.Err() instead of wrapping as
+	// retryable. That branch is the whole point of this test.
+	srv := newStatusServer(t, http.StatusOK, "", nil)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+	err := sink.Send(ctx, msgFor(srv.URL))
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("Send returned %v, want context.Canceled", err)
+	}
+	// The whole point of the special-case: dispatcher shutdown isn't transient.
+	if sinks.IsRetryable(err) {
+		t.Error("context.Canceled was classified as retryable")
+	}
+}
+
+func TestHTTPSink_EmptyDestinationTerminal(t *testing.T) {
+	sink := sinks.NewHTTPSink()
+	err := sink.Send(t.Context(), sinks.Message{ID: 1, Payload: []byte(`{}`)})
+	if err == nil {
+		t.Fatal("Send returned nil for empty destination")
+	}
+	if sinks.IsRetryable(err) {
+		t.Error("empty destination classified as retryable")
+	}
+	if !strings.Contains(err.Error(), "destination") {
+		t.Errorf("error %q should mention 'destination' for diagnosability", err)
+	}
+}
+
+func TestHTTPSink_ErrorIncludesBodySnippet(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"terminal_4xx", http.StatusForbidden, `{"error":"account suspended"}`, "account suspended"},
+		{"retryable_5xx", http.StatusServiceUnavailable, `{"error":"upstream queue full"}`, "upstream queue full"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := newStatusServer(t, tc.status, tc.body, nil)
+			sink := sinks.NewHTTPSink(sinks.WithHTTPClient(srv.Client()))
+
+			err := sink.Send(t.Context(), msgFor(srv.URL))
+			if err == nil {
+				t.Fatal("Send returned nil")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q missing body snippet %q", err, tc.want)
+			}
+			if !strings.Contains(err.Error(), strconv.Itoa(tc.status)) {
+				t.Errorf("error %q missing status code %d", err, tc.status)
+			}
+		})
+	}
+}
+
+// --- helpers ---
+
+func msgFor(url string) sinks.Message {
+	return sinks.Message{
+		ID:          1,
+		Destination: url,
+		Payload:     []byte(`{}`),
+	}
+}
+
+// newStatusServer responds with the given status, optional body, and
+// optional header set. Cleanup is registered on t.
+func newStatusServer(t *testing.T, status int, body string, headers http.Header) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		for k, vs := range headers {
+			for _, v := range vs {
+				w.Header().Add(k, v)
+			}
+		}
+		w.WriteHeader(status)
+		if body != "" {
+			_, _ = fmt.Fprint(w, body)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/internal/outbox/sinks/sink.go
+++ b/internal/outbox/sinks/sink.go
@@ -1,0 +1,122 @@
+// Package sinks defines the abstraction the outbox dispatcher uses to
+// deliver events. Each Sink implementation (HTTP now, Kafka in v0.2.0)
+// sends a Message; classification of failures into retryable vs terminal
+// lets the dispatcher (#6) drive its retry/dead-letter policy without
+// knowing transport-specific details.
+package sinks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Canonical sink names returned by Name() implementations. These values
+// match the outbox table's CHECK constraint
+// (migrations/0001_outbox.up.sql) — keep in sync.
+const (
+	SinkHTTP  = "http"
+	SinkKafka = "kafka"
+)
+
+// Sink delivers an outbox Message to its destination.
+type Sink interface {
+	// Send delivers msg or returns an error. A *RetryableError signals
+	// the dispatcher to schedule a retry; any other error is terminal
+	// and promotes the row to dead.
+	Send(ctx context.Context, msg Message) error
+
+	// Name identifies the sink for metric labels. Returns one of the
+	// canonical values declared in this package (SinkHTTP, SinkKafka).
+	Name() string
+}
+
+// Message is a single outbox row prepared for dispatch. Field set
+// mirrors the columns the dispatcher needs to expose at the wire layer:
+// IDs become headers/keys, payload becomes the body, trace context
+// becomes W3C headers.
+type Message struct {
+	// ID is the outbox row id, used as the Idempotency-Key on the wire
+	// so consumers can dedupe redelivered events.
+	ID int64
+
+	// Aggregate identifiers from the outbox row. AggregateID also serves
+	// as the canonical partition key for the Kafka sink (v0.2.0).
+	AggregateType string
+	AggregateID   string
+	EventType     string
+
+	// Destination is sink-specific: URL for HTTP, topic for Kafka.
+	// Must be non-empty; sinks return a terminal (non-retryable) error
+	// otherwise so the row promotes to dead instead of retry-looping.
+	Destination string
+
+	// Payload is the raw JSONB bytes from the outbox row, sent as the
+	// body verbatim (no envelope).
+	Payload []byte
+
+	// Traceparent and Tracestate carry the W3C trace context propagated
+	// from the producer through the outbox row. Sinks emit these as
+	// reserved headers on the wire; they are not user-controlled.
+	Traceparent string
+	Tracestate  string
+
+	// Headers carry user-supplied headers from the outbox.headers JSONB
+	// column. Sinks merge these with reserved headers (Content-Type,
+	// Idempotency-Key, traceparent, tracestate); on conflict, the sink's
+	// reserved header wins so user data can never overwrite the wire
+	// contract. The HTTP sink compares header names case-insensitively
+	// (per RFC 7230); the Kafka sink keeps them case-sensitive.
+	Headers map[string]string
+}
+
+// RetryableError marks a transport failure the dispatcher should retry.
+// RetryAfter > 0 (e.g. server returned a Retry-After header) overrides
+// the dispatcher's computed exponential backoff for that one attempt.
+//
+// HTTP-date variants of the Retry-After header must be converted to a
+// duration by the sink before constructing the error.
+type RetryableError struct {
+	Cause      error
+	RetryAfter time.Duration
+}
+
+// NewRetryableError wraps cause as a *RetryableError. retryAfter < 0 is
+// clamped to 0 so callers don't need a guard before calling.
+func NewRetryableError(cause error, retryAfter time.Duration) *RetryableError {
+	if retryAfter < 0 {
+		retryAfter = 0
+	}
+	return &RetryableError{Cause: cause, RetryAfter: retryAfter}
+}
+
+// Error implements error.
+func (e *RetryableError) Error() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("retryable (after %s): %v", e.RetryAfter, e.Cause)
+	}
+	return fmt.Sprintf("retryable: %v", e.Cause)
+}
+
+// Unwrap exposes the underlying cause for errors.Is/As.
+func (e *RetryableError) Unwrap() error { return e.Cause }
+
+// IsRetryable reports whether err (or any error it wraps) is a
+// *RetryableError. Boolean-only path for callers that don't need
+// RetryAfter; use AsRetryable when you do.
+func IsRetryable(err error) bool {
+	var re *RetryableError
+	return errors.As(err, &re)
+}
+
+// AsRetryable returns the *RetryableError when err (or any error it
+// wraps) is one. The dispatcher uses this to read RetryAfter without
+// a second errors.As call.
+func AsRetryable(err error) (*RetryableError, bool) {
+	var re *RetryableError
+	if errors.As(err, &re) {
+		return re, true
+	}
+	return nil, false
+}

--- a/internal/outbox/sinks/sink_test.go
+++ b/internal/outbox/sinks/sink_test.go
@@ -1,0 +1,110 @@
+package sinks_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ronango/pgrelay/internal/outbox/sinks"
+)
+
+func TestRetryableError_Error(t *testing.T) {
+	cases := []struct {
+		name string
+		err  *sinks.RetryableError
+		want string
+	}{
+		{
+			name: "with_retry_after",
+			err:  &sinks.RetryableError{Cause: errors.New("503 Service Unavailable"), RetryAfter: 5 * time.Second},
+			want: "retryable (after 5s): 503 Service Unavailable",
+		},
+		{
+			name: "no_retry_after",
+			err:  &sinks.RetryableError{Cause: errors.New("connection reset")},
+			want: "retryable: connection reset",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Errorf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRetryableError_Unwrap(t *testing.T) {
+	cause := errors.New("boom")
+	wrapped := &sinks.RetryableError{Cause: cause}
+
+	if got := errors.Unwrap(wrapped); !errors.Is(got, cause) {
+		t.Errorf("Unwrap = %v, want %v", got, cause)
+	}
+	if !errors.Is(wrapped, cause) {
+		t.Error("errors.Is should match wrapped cause")
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	retryable := &sinks.RetryableError{Cause: errors.New("503")}
+	nilCause := &sinks.RetryableError{} // zero-value is still retryable
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain_error", errors.New("terminal"), false},
+		{"direct_retryable", retryable, true},
+		{"wrapped_once", fmt.Errorf("send: %w", retryable), true},
+		{"wrapped_twice", fmt.Errorf("dispatch: %w", fmt.Errorf("send: %w", retryable)), true},
+		{"nil_cause_still_retryable", nilCause, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sinks.IsRetryable(tc.err); got != tc.want {
+				t.Errorf("IsRetryable(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAsRetryable(t *testing.T) {
+	retryable := sinks.NewRetryableError(errors.New("503"), 5*time.Second)
+
+	cases := []struct {
+		name        string
+		err         error
+		wantOK      bool
+		wantRA      time.Duration
+		wantCauseOK bool
+	}{
+		{"plain_error", errors.New("x"), false, 0, false},
+		{"retryable_with_after", retryable, true, 5 * time.Second, true},
+		{"retryable_wrapped", fmt.Errorf("send: %w", retryable), true, 5 * time.Second, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			re, ok := sinks.AsRetryable(tc.err)
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if re.RetryAfter != tc.wantRA {
+				t.Errorf("RetryAfter = %s, want %s", re.RetryAfter, tc.wantRA)
+			}
+		})
+	}
+}
+
+func TestNewRetryableError_ClampsNegativeRetryAfter(t *testing.T) {
+	got := sinks.NewRetryableError(errors.New("x"), -5*time.Second)
+	if got.RetryAfter != 0 {
+		t.Errorf("RetryAfter = %s, want 0 (negative clamped)", got.RetryAfter)
+	}
+}

--- a/internal/outbox/sinks/sinkmock/mock.go
+++ b/internal/outbox/sinks/sinkmock/mock.go
@@ -1,0 +1,114 @@
+// Package sinkmock provides a test-only sinks.Sink implementation for
+// the dispatcher tests in #6. It records every Message passed to Send,
+// supports a queue of errors to return on subsequent calls, and exposes
+// a callback hook for dynamic per-call behavior. Production code must
+// not import this package.
+//
+// For tests that assert dispatcher metric labels (e.g. histogram
+// `sink="http"`), construct with the canonical sink name from the sinks
+// package: sinkmock.New(sinks.SinkHTTP).
+//
+// SetOnSend takes precedence over EnqueueErrors. A test that sets a
+// callback and forgets to clear it can mask later error-queue setup;
+// call Reset between sub-tests reusing the same mock.
+package sinkmock
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ronango/pgrelay/internal/outbox/sinks"
+)
+
+// Compile-time check that *Sink satisfies sinks.Sink.
+var _ sinks.Sink = (*Sink)(nil)
+
+// SendFunc is the signature of the per-call callback installed via
+// SetOnSend. The ctx is the same one passed to Send so cancellation
+// tests can observe shutdown propagation.
+type SendFunc func(ctx context.Context, msg sinks.Message) error
+
+// Sink is a thread-safe mock of sinks.Sink.
+type Sink struct {
+	mu     sync.Mutex
+	name   string
+	sent   []sinks.Message
+	errs   []error
+	onSend SendFunc
+}
+
+// New returns a Sink with the given name. Empty name defaults to "mock"
+// so tests can construct a baseline mock without arguments.
+func New(name string) *Sink {
+	if name == "" {
+		name = "mock"
+	}
+	return &Sink{name: name}
+}
+
+// Name implements sinks.Sink.
+func (s *Sink) Name() string { return s.name }
+
+// Send records msg and returns the next queued behavior. Precedence:
+// onSend callback (if set) takes priority; otherwise the head of the
+// errors queue is consumed; once exhausted, Send returns nil.
+func (s *Sink) Send(ctx context.Context, msg sinks.Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.sent = append(s.sent, msg)
+
+	if s.onSend != nil {
+		return s.onSend(ctx, msg)
+	}
+	if len(s.errs) > 0 {
+		err := s.errs[0]
+		s.errs = s.errs[1:]
+		return err
+	}
+	return nil
+}
+
+// Sent returns a snapshot of recorded messages in receive order.
+func (s *Sink) Sent() []sinks.Message {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]sinks.Message, len(s.sent))
+	copy(out, s.sent)
+	return out
+}
+
+// SentCount returns the number of recorded messages without allocating.
+func (s *Sink) SentCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.sent)
+}
+
+// EnqueueErrors appends to the per-call error queue. nil entries are
+// successes; the queue is consumed in order. After exhaustion Send
+// returns nil. Multiple calls compose: queueing 3 errors then 2 more
+// yields a 5-deep queue.
+func (s *Sink) EnqueueErrors(errs ...error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errs = append(s.errs, errs...)
+}
+
+// SetOnSend installs a callback invoked on every Send. Takes precedence
+// over EnqueueErrors. Pass nil to clear.
+func (s *Sink) SetOnSend(fn SendFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onSend = fn
+}
+
+// Reset clears recorded messages, the error queue, and the onSend hook.
+// Useful between sub-tests reusing the same mock.
+func (s *Sink) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sent = nil
+	s.errs = nil
+	s.onSend = nil
+}

--- a/internal/outbox/sinks/sinkmock/mock_test.go
+++ b/internal/outbox/sinks/sinkmock/mock_test.go
@@ -1,0 +1,175 @@
+package sinkmock_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/ronango/pgrelay/internal/outbox/sinks"
+	"github.com/ronango/pgrelay/internal/outbox/sinks/sinkmock"
+)
+
+func TestNew_DefaultName(t *testing.T) {
+	if got := sinkmock.New("").Name(); got != "mock" {
+		t.Errorf("Name() = %q, want mock", got)
+	}
+}
+
+func TestNew_CustomName(t *testing.T) {
+	if got := sinkmock.New(sinks.SinkHTTP).Name(); got != "http" {
+		t.Errorf("Name() = %q, want http", got)
+	}
+}
+
+func TestSink_RecordsSentMessages(t *testing.T) {
+	m := sinkmock.New("")
+
+	for _, id := range []int64{1, 2, 3} {
+		if err := m.Send(t.Context(), sinks.Message{ID: id}); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+	}
+
+	if got := m.SentCount(); got != 3 {
+		t.Errorf("SentCount = %d, want 3", got)
+	}
+	got := m.Sent()
+	if len(got) != 3 {
+		t.Fatalf("Sent len = %d, want 3", len(got))
+	}
+	for i, id := range []int64{1, 2, 3} {
+		if got[i].ID != id {
+			t.Errorf("Sent[%d].ID = %d, want %d", i, got[i].ID, id)
+		}
+	}
+}
+
+func TestSink_EnqueueErrorsConsumesInOrder(t *testing.T) {
+	boom := errors.New("boom")
+	m := sinkmock.New("")
+	m.EnqueueErrors(boom, nil, boom)
+
+	results := make([]error, 4)
+	for i := range results {
+		results[i] = m.Send(t.Context(), sinks.Message{ID: int64(i)})
+	}
+
+	wants := []error{boom, nil, boom, nil} // 4th call: queue exhausted, returns nil
+	for i, want := range wants {
+		if !errors.Is(results[i], want) {
+			t.Errorf("Send[%d] = %v, want %v", i, results[i], want)
+		}
+	}
+}
+
+func TestSink_EnqueueErrorsAppends(t *testing.T) {
+	a, b := errors.New("a"), errors.New("b")
+	m := sinkmock.New("")
+	m.EnqueueErrors(a)
+	m.EnqueueErrors(b) // appends, doesn't replace
+
+	results := []error{
+		m.Send(t.Context(), sinks.Message{ID: 1}),
+		m.Send(t.Context(), sinks.Message{ID: 2}),
+	}
+	if !errors.Is(results[0], a) || !errors.Is(results[1], b) {
+		t.Errorf("got %v, want [a, b]", results)
+	}
+}
+
+func TestSink_OnSendCallbackTakesPrecedence(t *testing.T) {
+	m := sinkmock.New("")
+	m.EnqueueErrors(errors.New("queued")) // would fire if callback wasn't set
+
+	called := 0
+	m.SetOnSend(func(_ context.Context, msg sinks.Message) error {
+		called++
+		if msg.ID%2 == 0 {
+			return errors.New("even ids fail")
+		}
+		return nil
+	})
+
+	if err := m.Send(t.Context(), sinks.Message{ID: 1}); err != nil {
+		t.Errorf("ID=1: %v, want nil", err)
+	}
+	if err := m.Send(t.Context(), sinks.Message{ID: 2}); err == nil || err.Error() != "even ids fail" {
+		t.Errorf("ID=2: %v, want even-ids-fail", err)
+	}
+	if called != 2 {
+		t.Errorf("callback called %d times, want 2", called)
+	}
+}
+
+func TestSink_OnSendReceivesContext(t *testing.T) {
+	m := sinkmock.New("")
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	var got error
+	m.SetOnSend(func(ctx context.Context, _ sinks.Message) error {
+		got = ctx.Err()
+		return got
+	})
+
+	if err := m.Send(ctx, sinks.Message{ID: 1}); !errors.Is(err, context.Canceled) {
+		t.Errorf("Send returned %v, want context.Canceled (callback should observe)", err)
+	}
+	if !errors.Is(got, context.Canceled) {
+		t.Errorf("callback observed ctx.Err = %v, want context.Canceled", got)
+	}
+}
+
+func TestSink_Reset_ClearsAllState(t *testing.T) {
+	m := sinkmock.New("")
+	_ = m.Send(t.Context(), sinks.Message{ID: 1})
+	m.EnqueueErrors(errors.New("x"))
+	m.SetOnSend(func(context.Context, sinks.Message) error { return nil })
+
+	m.Reset()
+
+	if got := m.SentCount(); got != 0 {
+		t.Errorf("SentCount after Reset = %d, want 0", got)
+	}
+	if err := m.Send(t.Context(), sinks.Message{ID: 99}); err != nil {
+		t.Errorf("Send after Reset: %v, want nil (queue/callback both cleared)", err)
+	}
+}
+
+func TestSink_ConcurrentSendsAreSafe(t *testing.T) {
+	m := sinkmock.New("")
+	const goroutines = 50
+	const perGoroutine = 20
+
+	var wg sync.WaitGroup
+	for g := range goroutines {
+		wg.Add(1)
+		go func(base int) {
+			defer wg.Done()
+			for i := range perGoroutine {
+				_ = m.Send(context.Background(), sinks.Message{ID: int64(base*perGoroutine + i)})
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	const total = goroutines * perGoroutine
+	sent := m.Sent()
+	if len(sent) != total {
+		t.Fatalf("Sent len = %d, want %d", len(sent), total)
+	}
+
+	// Assert no message was lost or duplicated under contention.
+	got := make([]int64, len(sent))
+	for i, msg := range sent {
+		got[i] = msg.ID
+	}
+	slices.Sort(got)
+	for i := 0; i < total; i++ {
+		if got[i] != int64(i) {
+			t.Fatalf("missing or duplicated ID under contention: got[%d] = %d", i, got[i])
+		}
+	}
+}


### PR DESCRIPTION
Closes #5.

Implements the issue's acceptance criteria — `Sink` interface + `Message`, HTTP sink with retryable classification + `Retry-After`, and a thread-safe mock for the dispatcher tests in #6. Notes cover only divergence and additions beyond issue scope.

## Diverged from issue scope

- **`Message` extended beyond a bare DB mirror.** Issue listed `ID / Destination / Payload / Headers`. Shipped also `AggregateType`, `AggregateID`, `EventType` (mirror outbox columns; `AggregateID` becomes Kafka partition key in v0.2) and split `Traceparent`/`Tracestate` into their own fields rather than co-mingling W3C trace context with user `Headers`. Sinks own those four reserved fields; the `Headers` map is strictly user-controlled.

- **Reserved-headers precedence locked at type layer, not only in HTTPSink.** Doc on `Message.Headers` states "the sink's reserved header wins on conflict; HTTP sink compares header names case-insensitively (RFC 7230); Kafka sink keeps them case-sensitive." HTTPSink enforces it via `http.CanonicalHeaderKey` lookup so user data can never overwrite `Content-Type`, `Idempotency-Key`, `traceparent`, or `tracestate` regardless of casing.

## Added beyond issue scope

- **Canonical sink-name constants** (`SinkHTTP`, `SinkKafka`) cross-referenced to the migration's CHECK constraint, so future sinks have one source of truth.

- **`AsRetryable(err) (*RetryableError, bool)`** in addition to the issue's boolean `IsRetryable` — the dispatcher (#6) reads `RetryAfter` without a second `errors.As`. Plus a `NewRetryableError` constructor that clamps negative `RetryAfter`.

- **`CheckRedirect: ErrUseLastResponse`** in HTTPSink — a 3xx response from the destination surfaces as terminal instead of silently re-POSTing the `Idempotency-Key` to a different host. Issue didn't specify redirect behaviour; the default behaviour would have been a foot-gun.

- **`ctx.Canceled` special-case in `Send`.** Dispatcher shutdown is not a retryable transport error; transport failures wrapped as retryable, ctx cancellation propagated as `ctx.Err()`.

- **Bounded body read (64 KiB) + error snippet** (first 512 trimmed bytes included in the error string). Slowloris defence and operator-readable failure context for dead-letter inspection.

- **`SendFunc` callback in sinkmock receives `ctx`** so cancellation tests in #6 can observe shutdown propagation through the dispatcher. `EnqueueErrors` uses append semantics so multiple calls compose.

## Verification

- `make build / test / lint / vuln` — green locally.
- CI on this PR: `floor`, `golangci-lint`, `govulncheck`, `unit (1.25)`, `integration (14/15/16/17)`.
