### PR TITLE
feat(outbox): dispatcher worker — claim, dispatch, lease, retry

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,21 @@ type Config struct {
 	OTLPHeaders      map[string]string `env:"PGRELAY_OTEL_OTLP_HEADERS"        envSeparator:"," envKeyValSeparator:"="`
 	TracesSampler    string            `env:"PGRELAY_OTEL_TRACES_SAMPLER"      envDefault:"parentbased_always_on"`
 	TracesSamplerArg string            `env:"PGRELAY_OTEL_TRACES_SAMPLER_ARG"`
+
+	// Outbox dispatcher — consumed by internal/outbox.
+	// Backoff: delay = min(RetryMax, RetryBase * 2^(attempt-1)) ± RetryJitter.
+	PollInterval  time.Duration `env:"PGRELAY_POLL_INTERVAL"  envDefault:"100ms"`
+	BatchSize     int32         `env:"PGRELAY_BATCH_SIZE"     envDefault:"100"`
+	LeaseDuration time.Duration `env:"PGRELAY_LEASE_DURATION" envDefault:"30s"`
+	MaxAttempts   int           `env:"PGRELAY_MAX_ATTEMPTS"   envDefault:"10"`
+	RetryBase     time.Duration `env:"PGRELAY_RETRY_BASE"     envDefault:"1s"`
+	RetryMax      time.Duration `env:"PGRELAY_RETRY_MAX"      envDefault:"5m"`
+	RetryJitter   float64       `env:"PGRELAY_RETRY_JITTER"   envDefault:"0.2"`
 }
+
+// maxBatchSize caps PGRELAY_BATCH_SIZE so a misconfigured env var can't
+// pull millions of rows into memory in one claim.
+const maxBatchSize = 10_000
 
 // validLogLevels is the strict subset accepted by every candidate logger
 // (slog / zap / zerolog). Widen here if the observability layer picks one
@@ -144,6 +158,31 @@ func (c *Config) Validate() error {
 		// Reject set-but-ignored arg explicitly: a no-op env var is a
 		// debugging trap when an operator sets it expecting an effect.
 		return fmt.Errorf("PGRELAY_OTEL_TRACES_SAMPLER_ARG: must be empty when sampler is %q (only used with *traceidratio)", c.TracesSampler)
+	}
+
+	if c.PollInterval <= 0 {
+		return fmt.Errorf("PGRELAY_POLL_INTERVAL: must be > 0, got %s", c.PollInterval)
+	}
+	if c.BatchSize < 1 || c.BatchSize > maxBatchSize {
+		return fmt.Errorf("PGRELAY_BATCH_SIZE: must be in [1, %d], got %d", maxBatchSize, c.BatchSize)
+	}
+	if c.LeaseDuration <= 0 {
+		return fmt.Errorf("PGRELAY_LEASE_DURATION: must be > 0, got %s", c.LeaseDuration)
+	}
+	if c.LeaseDuration <= c.PollInterval {
+		return fmt.Errorf("PGRELAY_LEASE_DURATION (%s) must be > PGRELAY_POLL_INTERVAL (%s)", c.LeaseDuration, c.PollInterval)
+	}
+	if c.MaxAttempts < 1 {
+		return fmt.Errorf("PGRELAY_MAX_ATTEMPTS: must be >= 1, got %d", c.MaxAttempts)
+	}
+	if c.RetryBase <= 0 {
+		return fmt.Errorf("PGRELAY_RETRY_BASE: must be > 0, got %s", c.RetryBase)
+	}
+	if c.RetryMax < c.RetryBase {
+		return fmt.Errorf("PGRELAY_RETRY_MAX (%s) must be >= PGRELAY_RETRY_BASE (%s)", c.RetryMax, c.RetryBase)
+	}
+	if c.RetryJitter < 0 || c.RetryJitter > 1 {
+		return fmt.Errorf("PGRELAY_RETRY_JITTER: must be in [0, 1], got %v", c.RetryJitter)
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -260,6 +260,127 @@ func TestLoad_OpsAddrIPv6(t *testing.T) {
 	}
 }
 
+func TestLoad_DispatcherDefaults(t *testing.T) {
+	t.Setenv("PGRELAY_DATABASE_URL", "postgres://localhost/test")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"PollInterval", cfg.PollInterval, 100 * time.Millisecond},
+		{"BatchSize", cfg.BatchSize, int32(100)},
+		{"LeaseDuration", cfg.LeaseDuration, 30 * time.Second},
+		{"MaxAttempts", cfg.MaxAttempts, 10},
+		{"RetryBase", cfg.RetryBase, time.Second},
+		{"RetryMax", cfg.RetryMax, 5 * time.Minute},
+		{"RetryJitter", cfg.RetryJitter, 0.2},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestLoad_DispatcherOverrides(t *testing.T) {
+	t.Setenv("PGRELAY_DATABASE_URL", "postgres://localhost/test")
+	t.Setenv("PGRELAY_POLL_INTERVAL", "250ms")
+	t.Setenv("PGRELAY_BATCH_SIZE", "50")
+	t.Setenv("PGRELAY_LEASE_DURATION", "1m")
+	t.Setenv("PGRELAY_MAX_ATTEMPTS", "5")
+	t.Setenv("PGRELAY_RETRY_BASE", "500ms")
+	t.Setenv("PGRELAY_RETRY_MAX", "10m")
+	t.Setenv("PGRELAY_RETRY_JITTER", "0.5")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"PollInterval", cfg.PollInterval, 250 * time.Millisecond},
+		{"BatchSize", cfg.BatchSize, int32(50)},
+		{"LeaseDuration", cfg.LeaseDuration, time.Minute},
+		{"MaxAttempts", cfg.MaxAttempts, 5},
+		{"RetryBase", cfg.RetryBase, 500 * time.Millisecond},
+		{"RetryMax", cfg.RetryMax, 10 * time.Minute},
+		{"RetryJitter", cfg.RetryJitter, 0.5},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+func TestLoad_DispatcherBoundaries(t *testing.T) {
+	// Boundary case: RetryMax == RetryBase is legal (no exponential growth,
+	// every retry waits exactly RetryBase ± jitter).
+	t.Setenv("PGRELAY_DATABASE_URL", "postgres://localhost/test")
+	t.Setenv("PGRELAY_RETRY_BASE", "5s")
+	t.Setenv("PGRELAY_RETRY_MAX", "5s")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load with RetryMax==RetryBase should succeed: %v", err)
+	}
+	if cfg.RetryBase != cfg.RetryMax {
+		t.Errorf("RetryBase=%s RetryMax=%s should be equal", cfg.RetryBase, cfg.RetryMax)
+	}
+}
+
+func TestLoad_DispatcherInvalid(t *testing.T) {
+	cases := []struct {
+		name   string
+		setEnv map[string]string
+		envKey string
+	}{
+		{"poll_interval_zero", map[string]string{"PGRELAY_POLL_INTERVAL": "0s"}, "PGRELAY_POLL_INTERVAL"},
+		{"poll_interval_negative", map[string]string{"PGRELAY_POLL_INTERVAL": "-100ms"}, "PGRELAY_POLL_INTERVAL"},
+		{"batch_size_zero", map[string]string{"PGRELAY_BATCH_SIZE": "0"}, "PGRELAY_BATCH_SIZE"},
+		{"lease_duration_zero", map[string]string{"PGRELAY_LEASE_DURATION": "0s"}, "PGRELAY_LEASE_DURATION"},
+		{"max_attempts_zero", map[string]string{"PGRELAY_MAX_ATTEMPTS": "0"}, "PGRELAY_MAX_ATTEMPTS"},
+		{"retry_base_zero", map[string]string{"PGRELAY_RETRY_BASE": "0s"}, "PGRELAY_RETRY_BASE"},
+		{"retry_jitter_negative", map[string]string{"PGRELAY_RETRY_JITTER": "-0.1"}, "PGRELAY_RETRY_JITTER"},
+		{"retry_jitter_above_one", map[string]string{"PGRELAY_RETRY_JITTER": "1.5"}, "PGRELAY_RETRY_JITTER"},
+		{"retry_max_below_base", map[string]string{
+			"PGRELAY_RETRY_BASE": "10s",
+			"PGRELAY_RETRY_MAX":  "1s",
+		}, "PGRELAY_RETRY_MAX"},
+		{"batch_size_above_ceiling", map[string]string{"PGRELAY_BATCH_SIZE": "100000"}, "PGRELAY_BATCH_SIZE"},
+		{"lease_duration_at_poll_interval", map[string]string{
+			"PGRELAY_LEASE_DURATION": "100ms",
+			"PGRELAY_POLL_INTERVAL":  "100ms",
+		}, "PGRELAY_LEASE_DURATION"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("PGRELAY_DATABASE_URL", "postgres://localhost/test")
+			for k, v := range tc.setEnv {
+				t.Setenv(k, v)
+			}
+
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.envKey) {
+				t.Errorf("error = %q, want substring %q", err, tc.envKey)
+			}
+		})
+	}
+}
+
 func TestLoad_ObservabilityInvalid(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/internal/outbox/claim.go
+++ b/internal/outbox/claim.go
@@ -18,20 +18,31 @@ import (
 // dispatchers — each row is claimed by exactly one caller. ORDER BY
 // includes `id` as a tiebreaker so rows inserted in the same transaction
 // (sharing a `next_attempt_at` from `now()`) dispatch deterministically.
+//
+// The CTE wrapper + final SELECT ORDER BY is required because UPDATE
+// RETURNING does not preserve subquery row order, and PostgreSQL does
+// not allow ORDER BY on UPDATE itself.
 func Claim(ctx context.Context, pool *pgxpool.Pool, batchSize int32, leaseDuration time.Duration) ([]Row, error) {
 	const sql = `
-		UPDATE pgrelay_outbox
-		SET status = 'in_flight',
-		    leased_until = now() + $2::interval,
-		    attempts = attempts + 1
-		WHERE id IN (
+		WITH due AS (
 			SELECT id FROM pgrelay_outbox
 			WHERE status = 'pending' AND next_attempt_at <= now()
 			ORDER BY next_attempt_at, id
 			FOR UPDATE SKIP LOCKED
 			LIMIT $1
+		),
+		updated AS (
+			UPDATE pgrelay_outbox
+			SET status = 'in_flight',
+			    leased_until = now() + $2::interval,
+			    attempts = attempts + 1
+			WHERE id IN (SELECT id FROM due)
+			RETURNING ` + rowColumns + `
 		)
-		RETURNING ` + rowColumns
+		SELECT ` + rowColumns + `
+		FROM updated
+		ORDER BY next_attempt_at, id
+	`
 
 	leaseInterval := pgtype.Interval{Microseconds: leaseDuration.Microseconds(), Valid: true}
 

--- a/internal/outbox/claim.go
+++ b/internal/outbox/claim.go
@@ -1,0 +1,43 @@
+package outbox
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Claim atomically transitions up to batchSize pending rows whose
+// next_attempt_at has passed to status='in_flight', extends their lease
+// by leaseDuration, increments attempts, and returns the locked rows.
+//
+// FOR UPDATE SKIP LOCKED makes the operation safe under concurrent
+// dispatchers — each row is claimed by exactly one caller. ORDER BY
+// includes `id` as a tiebreaker so rows inserted in the same transaction
+// (sharing a `next_attempt_at` from `now()`) dispatch deterministically.
+func Claim(ctx context.Context, pool *pgxpool.Pool, batchSize int32, leaseDuration time.Duration) ([]Row, error) {
+	const sql = `
+		UPDATE pgrelay_outbox
+		SET status = 'in_flight',
+		    leased_until = now() + $2::interval,
+		    attempts = attempts + 1
+		WHERE id IN (
+			SELECT id FROM pgrelay_outbox
+			WHERE status = 'pending' AND next_attempt_at <= now()
+			ORDER BY next_attempt_at, id
+			FOR UPDATE SKIP LOCKED
+			LIMIT $1
+		)
+		RETURNING ` + rowColumns
+
+	leaseInterval := pgtype.Interval{Microseconds: leaseDuration.Microseconds(), Valid: true}
+
+	rows, err := pool.Query(ctx, sql, batchSize, leaseInterval)
+	if err != nil {
+		return nil, fmt.Errorf("claim query: %w", err)
+	}
+	return pgx.CollectRows(rows, scanRow)
+}

--- a/internal/outbox/dispatcher.go
+++ b/internal/outbox/dispatcher.go
@@ -104,6 +104,13 @@ func (d *Dispatcher) dispatch(ctx context.Context, row Row) {
 	// Observed on every outcome so failure tails land in the histogram.
 	d.metrics.DispatchDuration.WithLabelValues(d.sink.Name()).Observe(time.Since(start).Seconds())
 
+	// Shutdown mid-Send: writing a terminal state would mask uncertainty
+	// — the request may or may not have hit the sink. Leave the row
+	// in_flight; the lease sweeper redelivers under at-least-once.
+	if errors.Is(sendErr, context.Canceled) || errors.Is(sendErr, context.DeadlineExceeded) {
+		return
+	}
+
 	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), finalizeTimeout)
 	defer cancel()
 

--- a/internal/outbox/dispatcher.go
+++ b/internal/outbox/dispatcher.go
@@ -1,0 +1,158 @@
+package outbox
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ronango/pgrelay/internal/config"
+	"github.com/ronango/pgrelay/internal/outbox/sinks"
+)
+
+// Dispatcher is the long-running outbox worker. One Run() per
+// Dispatcher; concurrent Runs would race the sink. Per-row
+// concurrency within a batch is deferred to v0.2.
+type Dispatcher struct {
+	pool    *pgxpool.Pool
+	sink    sinks.Sink
+	policy  *Policy
+	metrics *Metrics
+	cfg     config.Config
+	log     *slog.Logger
+}
+
+// finalizeTimeout caps the detached terminal-write so a canceled
+// dispatch still persists its outcome instead of leaking to the sweeper.
+const finalizeTimeout = 5 * time.Second
+
+// New wires a Dispatcher.
+func New(pool *pgxpool.Pool, sink sinks.Sink, policy *Policy, metrics *Metrics, cfg config.Config, log *slog.Logger) *Dispatcher {
+	return &Dispatcher{
+		pool:    pool,
+		sink:    sink,
+		policy:  policy,
+		metrics: metrics,
+		cfg:     cfg,
+		log:     log,
+	}
+}
+
+// Run blocks until ctx is canceled, then returns ctx.Err().
+func (d *Dispatcher) Run(ctx context.Context) error {
+	sweep := d.cfg.LeaseDuration / 2
+	pollTicker := time.NewTicker(d.cfg.PollInterval)
+	defer pollTicker.Stop()
+	sweepTicker := time.NewTicker(sweep)
+	defer sweepTicker.Stop()
+
+	d.log.InfoContext(ctx, "dispatcher started",
+		"sink", d.sink.Name(),
+		"poll", d.cfg.PollInterval,
+		"sweep", sweep,
+		"batch", d.cfg.BatchSize,
+		"lease", d.cfg.LeaseDuration,
+		"max_attempts", d.policy.MaxAttempts,
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			d.log.InfoContext(ctx, "dispatcher stopping", "reason", ctx.Err())
+			return ctx.Err()
+		case <-pollTicker.C:
+			d.poll(ctx)
+		case <-sweepTicker.C:
+			d.sweep(ctx)
+		}
+	}
+}
+
+func (d *Dispatcher) poll(ctx context.Context) {
+	rows, err := Claim(ctx, d.pool, d.cfg.BatchSize, d.cfg.LeaseDuration)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			d.log.WarnContext(ctx, "claim failed", "err", err)
+		}
+		return
+	}
+	for _, row := range rows {
+		if ctx.Err() != nil {
+			return
+		}
+		d.dispatch(ctx, row)
+	}
+}
+
+func (d *Dispatcher) dispatch(ctx context.Context, row Row) {
+	msg := sinks.Message{
+		ID:            row.ID,
+		AggregateType: row.AggregateType,
+		AggregateID:   row.AggregateID,
+		EventType:     row.EventType,
+		Destination:   row.Destination,
+		Payload:       row.Payload,
+		Headers:       row.Headers,
+		Traceparent:   row.Traceparent,
+		Tracestate:    row.Tracestate,
+	}
+
+	start := time.Now()
+	sendErr := d.sink.Send(ctx, msg)
+	// Observed on every outcome so failure tails land in the histogram.
+	d.metrics.DispatchDuration.WithLabelValues(d.sink.Name()).Observe(time.Since(start).Seconds())
+
+	writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), finalizeTimeout)
+	defer cancel()
+
+	switch {
+	case sendErr == nil:
+		if err := MarkSent(writeCtx, d.pool, row.ID); err != nil {
+			d.log.ErrorContext(writeCtx, "mark sent failed", "id", row.ID, "err", err)
+			return
+		}
+		d.metrics.Attempts.WithLabelValues(ResultSent).Inc()
+	case !sinks.IsRetryable(sendErr) || row.Attempts >= d.policy.MaxAttempts:
+		errStr := sendErr.Error()
+		if err := MarkDead(writeCtx, d.pool, row.ID, errStr); err != nil {
+			d.log.ErrorContext(writeCtx, "mark dead failed", "id", row.ID, "err", err, "last_error", errStr)
+			return
+		}
+		d.metrics.Attempts.WithLabelValues(ResultDead).Inc()
+	default:
+		d.scheduleRetry(writeCtx, row, sendErr)
+	}
+}
+
+// scheduleRetry uses RetryAfter as a floor over policy.NextDelay,
+// clamped to policy.Max so a misbehaving origin can't park a row
+// past the operator-configured ceiling.
+func (d *Dispatcher) scheduleRetry(ctx context.Context, row Row, sendErr error) {
+	delay := d.policy.NextDelay(row.Attempts)
+	if re, ok := sinks.AsRetryable(sendErr); ok {
+		delay = min(max(delay, re.RetryAfter), d.policy.Max)
+	}
+	nextAt := time.Now().Add(delay)
+
+	if err := MarkRetry(ctx, d.pool, row.ID, nextAt, sendErr.Error()); err != nil {
+		d.log.ErrorContext(ctx, "mark retry failed", "id", row.ID, "err", err)
+		return
+	}
+	d.metrics.Attempts.WithLabelValues(ResultRetry).Inc()
+}
+
+func (d *Dispatcher) sweep(ctx context.Context) {
+	n, err := ReclaimOrphans(ctx, d.pool)
+	if err != nil {
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			d.log.WarnContext(ctx, "sweep failed", "err", err)
+		}
+		return
+	}
+	if n > 0 {
+		d.metrics.OrphansReclaimed.Add(float64(n))
+		d.log.InfoContext(ctx, "reclaimed orphaned rows", "count", n)
+	}
+}

--- a/internal/outbox/dispatcher_integration_test.go
+++ b/internal/outbox/dispatcher_integration_test.go
@@ -1,0 +1,252 @@
+//go:build integration
+
+package outbox_test
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/ronango/pgrelay/internal/config"
+	"github.com/ronango/pgrelay/internal/outbox"
+	"github.com/ronango/pgrelay/internal/outbox/sinks"
+	"github.com/ronango/pgrelay/internal/outbox/sinks/sinkmock"
+	"github.com/ronango/pgrelay/internal/testdb"
+)
+
+// dispatcherFixture starts Run() and registers cancel/wait via t.Cleanup.
+type dispatcherFixture struct {
+	Pool    *pgxpool.Pool
+	Sink    *sinkmock.Sink
+	Metrics *outbox.Metrics
+	Reg     *prometheus.Registry
+	Cfg     config.Config
+
+	cancel context.CancelFunc
+	done   chan error
+}
+
+// fastConfig is the dispatcher tuning used by these tests — short
+// intervals so a test can observe a full poll+sweep cycle in <500ms.
+func fastConfig() config.Config {
+	return config.Config{
+		PollInterval:  10 * time.Millisecond,
+		BatchSize:     32,
+		LeaseDuration: 500 * time.Millisecond,
+		MaxAttempts:   3,
+		RetryBase:     10 * time.Millisecond,
+		RetryMax:      50 * time.Millisecond,
+		RetryJitter:   0,
+	}
+}
+
+func startDispatcher(t *testing.T, pool *pgxpool.Pool, cfg config.Config) *dispatcherFixture {
+	t.Helper()
+
+	sink := sinkmock.New(sinks.SinkHTTP)
+	policy := outbox.NewPolicy(cfg)
+	reg := prometheus.NewRegistry()
+	metrics := outbox.NewMetrics(reg)
+	d := outbox.New(pool, sink, policy, metrics, cfg, quietLogger())
+
+	ctx, cancel := context.WithCancel(t.Context())
+	done := make(chan error, 1)
+	go func() { done <- d.Run(ctx) }()
+
+	f := &dispatcherFixture{
+		Pool: pool, Sink: sink, Metrics: metrics, Reg: reg, Cfg: cfg,
+		cancel: cancel, done: done,
+	}
+	t.Cleanup(f.Stop)
+	return f
+}
+
+// attemptsCount returns the Attempts counter for a given result label.
+func (f *dispatcherFixture) attemptsCount(result string) float64 {
+	return testutil.ToFloat64(f.Metrics.Attempts.WithLabelValues(result))
+}
+
+// Stop cancels the dispatcher and waits up to 2s for Run to return.
+// Idempotent — second call sees a closed channel and returns immediately.
+func (f *dispatcherFixture) Stop() {
+	f.cancel()
+	select {
+	case <-f.done:
+	case <-time.After(2 * time.Second):
+	}
+}
+
+func TestDispatcher_HappyPath(t *testing.T) {
+	pool := testdb.New(t)
+	f := startDispatcher(t, pool, fastConfig())
+
+	id := insertRow(t, pool, insertOpts{})
+
+	r := waitForStatus(t, pool, id, "sent", 2*time.Second)
+	if r.Attempts != 1 {
+		t.Errorf("Attempts = %d, want 1", r.Attempts)
+	}
+	if r.LeasedUntil != nil {
+		t.Errorf("LeasedUntil = %v, want NULL after sent", r.LeasedUntil)
+	}
+	if f.Sink.SentCount() == 0 {
+		t.Error("sink received no messages")
+	}
+	if got := f.attemptsCount(outbox.ResultSent); got < 1 {
+		t.Errorf("attempts_total{sent} = %v, want >= 1", got)
+	}
+}
+
+func TestDispatcher_NonRetryableMarksDead(t *testing.T) {
+	pool := testdb.New(t)
+	f := startDispatcher(t, pool, fastConfig())
+
+	f.Sink.EnqueueErrors(errors.New("400 Bad Request"))
+	id := insertRow(t, pool, insertOpts{})
+
+	r := waitForStatus(t, pool, id, "dead", 2*time.Second)
+	if r.LastError == "" {
+		t.Error("LastError empty, want sink error text")
+	}
+	if got := f.attemptsCount(outbox.ResultDead); got < 1 {
+		t.Errorf("attempts_total{dead} = %v, want >= 1", got)
+	}
+}
+
+func TestDispatcher_RetryableReschedules(t *testing.T) {
+	pool := testdb.New(t)
+	f := startDispatcher(t, pool, fastConfig())
+
+	f.Sink.EnqueueErrors(sinks.NewRetryableError(errors.New("503"), 0), nil)
+	id := insertRow(t, pool, insertOpts{})
+
+	r := waitForStatus(t, pool, id, "sent", 3*time.Second)
+	if r.Attempts < 2 {
+		t.Errorf("Attempts = %d, want >= 2 (one retry + one success)", r.Attempts)
+	}
+	if f.Sink.SentCount() < 2 {
+		t.Errorf("sink saw %d messages, want >= 2", f.Sink.SentCount())
+	}
+	if got := f.attemptsCount(outbox.ResultRetry); got < 1 {
+		t.Errorf("attempts_total{retry} = %v, want >= 1", got)
+	}
+	if got := f.attemptsCount(outbox.ResultSent); got < 1 {
+		t.Errorf("attempts_total{sent} = %v, want >= 1", got)
+	}
+}
+
+func TestDispatcher_MaxAttemptsExhaustedGoesDead(t *testing.T) {
+	pool := testdb.New(t)
+	cfg := fastConfig()
+	cfg.MaxAttempts = 2
+	f := startDispatcher(t, pool, cfg)
+
+	// Always retryable — dispatcher should give up after MaxAttempts.
+	f.Sink.SetOnSend(func(_ context.Context, _ sinks.Message) error {
+		return sinks.NewRetryableError(errors.New("503"), 0)
+	})
+
+	id := insertRow(t, pool, insertOpts{})
+	r := waitForStatus(t, pool, id, "dead", 3*time.Second)
+	if r.Attempts < cfg.MaxAttempts {
+		t.Errorf("Attempts = %d, want >= %d", r.Attempts, cfg.MaxAttempts)
+	}
+}
+
+func TestDispatcher_RetryAfterIsFloor(t *testing.T) {
+	pool := testdb.New(t)
+	cfg := fastConfig()
+	// Make policy's NextDelay tiny so RetryAfter clearly wins.
+	cfg.RetryBase = time.Millisecond
+	cfg.RetryMax = 5 * time.Second
+	f := startDispatcher(t, pool, cfg)
+
+	const retryAfter = 800 * time.Millisecond
+	var sent atomic.Int32
+	f.Sink.SetOnSend(func(_ context.Context, _ sinks.Message) error {
+		if sent.Add(1) == 1 {
+			return sinks.NewRetryableError(errors.New("429 slow down"), retryAfter)
+		}
+		return nil
+	})
+
+	id := insertRow(t, pool, insertOpts{})
+
+	// First attempt fails; row goes back to pending with next_attempt_at
+	// far enough in the future that the dispatcher cannot have retried
+	// yet — exactly the floor we want to verify.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		r := getRow(t, pool, id)
+		if r.Status == "pending" && r.Attempts == 1 {
+			gap := time.Until(r.NextAttemptAt)
+			// Allow some slack for ticker latency.
+			if gap < retryAfter-100*time.Millisecond {
+				t.Errorf("NextAttemptAt gap = %s, want ≈ %s (RetryAfter floor)", gap, retryAfter)
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("never observed retry state for row %d", id)
+}
+
+func TestDispatcher_SweepsOrphans(t *testing.T) {
+	pool := testdb.New(t)
+	f := startDispatcher(t, pool, fastConfig())
+
+	// Pre-orphaned: in_flight with lease already expired. Sweeper
+	// returns it to pending, then dispatcher re-delivers.
+	id := insertRow(t, pool, insertOpts{
+		Status:      "in_flight",
+		Attempts:    1,
+		LeasedUntil: time.Now().Add(-time.Second),
+	})
+
+	r := waitForStatus(t, pool, id, "sent", 3*time.Second)
+	if r.LastError != "" {
+		t.Errorf("LastError = %q, want cleared by MarkSent after redelivery", r.LastError)
+	}
+	if f.Sink.SentCount() == 0 {
+		t.Error("orphan never re-dispatched")
+	}
+	if got := testutil.ToFloat64(f.Metrics.OrphansReclaimed); got < 1 {
+		t.Errorf("orphans_reclaimed_total = %v, want >= 1", got)
+	}
+}
+
+func TestDispatcher_ShutdownLeavesInFlightForSweeper(t *testing.T) {
+	// At-least-once invariant: when Send returns ctx.Canceled (or
+	// DeadlineExceeded), we cannot tell whether the request reached
+	// the sink. Marking the row dead would lose redelivery; the lease
+	// sweeper must own recovery.
+	pool := testdb.New(t)
+	f := startDispatcher(t, pool, fastConfig())
+
+	released := make(chan struct{})
+	f.Sink.SetOnSend(func(ctx context.Context, _ sinks.Message) error {
+		<-ctx.Done()
+		close(released)
+		return ctx.Err()
+	})
+
+	id := insertRow(t, pool, insertOpts{})
+	waitForStatus(t, pool, id, "in_flight", 2*time.Second)
+
+	f.Stop()
+	<-released
+
+	r := getRow(t, pool, id)
+	if r.Status != "in_flight" {
+		t.Errorf("post-shutdown status = %q, want in_flight", r.Status)
+	}
+	if r.LastError != "" {
+		t.Errorf("LastError = %q, want empty (no terminal write)", r.LastError)
+	}
+}

--- a/internal/outbox/metrics.go
+++ b/internal/outbox/metrics.go
@@ -1,0 +1,124 @@
+package outbox
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Metrics is the dispatcher's Prometheus surface for eagerly-tracked
+// signals; live gauges are in stateCollector.
+type Metrics struct {
+	// Retries increment Attempts too — sum across labels is total
+	// attempts, not unique rows.
+	Attempts         *prometheus.CounterVec
+	DispatchDuration *prometheus.HistogramVec
+	OrphansReclaimed prometheus.Counter
+}
+
+// dispatchDurationBuckets: 5ms..30s covers typical webhook RTTs and
+// puts the top bucket above any plausible HTTPSink Timeout, so a
+// stuck sink shows as +Inf rather than getting lost in the tail.
+var dispatchDurationBuckets = []float64{0.005, 0.025, 0.1, 0.5, 1, 5, 15, 30}
+
+// NewMetrics panics on duplicate registration; the process owns one
+// Registerer, so duplicates indicate a programming bug at boot.
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		Attempts: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "pgrelay_outbox_attempts_total",
+			Help: "Total dispatch attempts, labeled by outcome (sent, retry, dead). Sum across labels is total attempts including retries.",
+		}, []string{"result"}),
+		DispatchDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "pgrelay_outbox_dispatch_duration_seconds",
+			Help:    "Wall-clock time spent in sink.Send per row, labeled by sink.",
+			Buckets: dispatchDurationBuckets,
+		}, []string{"sink"}),
+		OrphansReclaimed: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: "pgrelay_outbox_orphans_reclaimed_total",
+			Help: "Total in_flight rows the lease sweeper returned to pending.",
+		}),
+	}
+	reg.MustRegister(m.Attempts, m.DispatchDuration, m.OrphansReclaimed)
+	return m
+}
+
+// stateCollector samples the outbox table once per scrape under a
+// bounded timeout so a slow DB can't wedge the /metrics endpoint.
+type stateCollector struct {
+	pool    *pgxpool.Pool
+	timeout time.Duration
+	log     *slog.Logger
+
+	backlog *prometheus.Desc
+	rows    *prometheus.Desc
+}
+
+// stateCollectorTimeout leaves headroom under the default 10s
+// Prometheus scrape timeout so other collectors still get a chance.
+const stateCollectorTimeout = 3 * time.Second
+
+// RegisterStateCollector adds gauges sampled on each scrape.
+func RegisterStateCollector(reg prometheus.Registerer, pool *pgxpool.Pool, log *slog.Logger) prometheus.Collector {
+	c := &stateCollector{
+		pool:    pool,
+		timeout: stateCollectorTimeout,
+		log:     log,
+		backlog: prometheus.NewDesc(
+			"pgrelay_outbox_backlog_seconds",
+			"Age of the oldest pending row past its next_attempt_at. 0 when nothing is due.",
+			nil, nil,
+		),
+		rows: prometheus.NewDesc(
+			"pgrelay_outbox_rows",
+			"Live row counts by status. 'dead' is omitted — query the table directly for triage.",
+			[]string{"status"}, nil,
+		),
+	}
+	reg.MustRegister(c)
+	return c
+}
+
+func (c *stateCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.backlog
+	ch <- c.rows
+}
+
+func (c *stateCollector) Collect(ch chan<- prometheus.Metric) {
+	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+	defer cancel()
+
+	// FILTER aggregates run over the partial indexes for both statuses;
+	// the planner typically combines them via BitmapOr.
+	const sql = `
+		SELECT
+			COALESCE(EXTRACT(EPOCH FROM (now() - MIN(next_attempt_at) FILTER (WHERE status = 'pending' AND next_attempt_at <= now()))), 0)::float8 AS backlog,
+			COUNT(*) FILTER (WHERE status = 'pending')   AS pending,
+			COUNT(*) FILTER (WHERE status = 'in_flight') AS in_flight
+		FROM pgrelay_outbox
+		WHERE status IN ('pending', 'in_flight')
+	`
+
+	var backlog float64
+	var pending, inFlight int64
+	if err := c.pool.QueryRow(ctx, sql).Scan(&backlog, &pending, &inFlight); err != nil {
+		// No-emit on failure: Prometheus surfaces absence as stale,
+		// which is more informative than a fabricated zero.
+		c.log.WarnContext(ctx, "outbox state collector query failed", "err", err)
+		return
+	}
+
+	ch <- prometheus.MustNewConstMetric(c.backlog, prometheus.GaugeValue, backlog)
+	ch <- prometheus.MustNewConstMetric(c.rows, prometheus.GaugeValue, float64(pending), "pending")
+	ch <- prometheus.MustNewConstMetric(c.rows, prometheus.GaugeValue, float64(inFlight), "in_flight")
+}
+
+// Result labels for Metrics.Attempts.
+const (
+	ResultSent  = "sent"
+	ResultRetry = "retry"
+	ResultDead  = "dead"
+)

--- a/internal/outbox/metrics_test.go
+++ b/internal/outbox/metrics_test.go
@@ -1,0 +1,56 @@
+package outbox_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/ronango/pgrelay/internal/outbox"
+)
+
+func TestNewMetrics_RegistersExpectedMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := outbox.NewMetrics(reg)
+
+	m.Attempts.WithLabelValues(outbox.ResultSent).Inc()
+	m.Attempts.WithLabelValues(outbox.ResultRetry).Inc()
+	m.Attempts.WithLabelValues(outbox.ResultDead).Inc()
+	m.DispatchDuration.WithLabelValues("http").Observe(0.1)
+	m.OrphansReclaimed.Inc()
+
+	// Histogram has one labeled series after the Observe above.
+	if got := testutil.CollectAndCount(m.DispatchDuration); got != 1 {
+		t.Errorf("DispatchDuration series count = %d, want 1", got)
+	}
+
+	want := `
+# HELP pgrelay_outbox_attempts_total Total dispatch attempts, labeled by outcome (sent, retry, dead). Sum across labels is total attempts including retries.
+# TYPE pgrelay_outbox_attempts_total counter
+pgrelay_outbox_attempts_total{result="dead"} 1
+pgrelay_outbox_attempts_total{result="retry"} 1
+pgrelay_outbox_attempts_total{result="sent"} 1
+# HELP pgrelay_outbox_orphans_reclaimed_total Total in_flight rows the lease sweeper returned to pending.
+# TYPE pgrelay_outbox_orphans_reclaimed_total counter
+pgrelay_outbox_orphans_reclaimed_total 1
+`
+	if err := testutil.GatherAndCompare(reg, strings.NewReader(want),
+		"pgrelay_outbox_attempts_total",
+		"pgrelay_outbox_orphans_reclaimed_total",
+	); err != nil {
+		t.Errorf("metrics mismatch: %v", err)
+	}
+}
+
+func TestNewMetrics_DuplicateRegistrationPanics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	outbox.NewMetrics(reg)
+
+	defer func() {
+		if recover() == nil {
+			t.Error("second NewMetrics on same registry should have panicked")
+		}
+	}()
+	outbox.NewMetrics(reg)
+}

--- a/internal/outbox/outbox_helpers_integration_test.go
+++ b/internal/outbox/outbox_helpers_integration_test.go
@@ -1,0 +1,135 @@
+//go:build integration
+
+package outbox_test
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// testRow narrower than outbox.Row so helpers don't depend on the
+// unexported scan plumbing.
+type testRow struct {
+	ID            int64
+	Status        string
+	Attempts      int
+	NextAttemptAt time.Time
+	LeasedUntil   *time.Time
+	LastError     string
+}
+
+// insertOpts: zero values fall back to schema defaults (status='pending',
+// attempts=0, next_attempt_at=now(), leased_until=NULL).
+type insertOpts struct {
+	AggregateType string
+	AggregateID   string
+	EventType     string
+	Payload       []byte
+	Sink          string
+	Destination   string
+
+	// Optional overrides — leave zero to accept the schema default.
+	Status        string
+	Attempts      int
+	NextAttemptAt time.Time
+	LeasedUntil   time.Time
+}
+
+// insertRow defaults produce a dispatchable pending row pointed at sink="http".
+func insertRow(t testing.TB, pool *pgxpool.Pool, o insertOpts) int64 {
+	t.Helper()
+	if o.AggregateType == "" {
+		o.AggregateType = "order"
+	}
+	if o.AggregateID == "" {
+		o.AggregateID = "agg-1"
+	}
+	if o.EventType == "" {
+		o.EventType = "created"
+	}
+	if o.Payload == nil {
+		o.Payload = []byte(`{"k":"v"}`)
+	}
+	if o.Sink == "" {
+		o.Sink = "http"
+	}
+	if o.Destination == "" {
+		o.Destination = "https://example.test/hook"
+	}
+	if o.Status == "" {
+		o.Status = "pending"
+	}
+
+	nextAt := pgtype.Timestamptz{Time: o.NextAttemptAt, Valid: !o.NextAttemptAt.IsZero()}
+	leased := pgtype.Timestamptz{Time: o.LeasedUntil, Valid: !o.LeasedUntil.IsZero()}
+
+	const sql = `
+		INSERT INTO pgrelay_outbox (
+			aggregate_type, aggregate_id, event_type, payload,
+			sink, destination, status, attempts,
+			next_attempt_at, leased_until
+		) VALUES (
+			$1, $2, $3, $4::jsonb,
+			$5, $6, $7, $8,
+			COALESCE($9::timestamptz, now()),
+			$10::timestamptz
+		)
+		RETURNING id
+	`
+	var id int64
+	err := pool.QueryRow(t.Context(), sql,
+		o.AggregateType, o.AggregateID, o.EventType, o.Payload,
+		o.Sink, o.Destination, o.Status, o.Attempts,
+		nextAt, leased,
+	).Scan(&id)
+	if err != nil {
+		t.Fatalf("insertRow: %v", err)
+	}
+	return id
+}
+
+func getRow(t testing.TB, pool *pgxpool.Pool, id int64) testRow {
+	t.Helper()
+	var r testRow
+	var leased pgtype.Timestamptz
+	var lastError pgtype.Text
+	err := pool.QueryRow(t.Context(), `
+		SELECT id, status, attempts, next_attempt_at, leased_until, last_error
+		FROM pgrelay_outbox
+		WHERE id = $1
+	`, id).Scan(&r.ID, &r.Status, &r.Attempts, &r.NextAttemptAt, &leased, &lastError)
+	if err != nil {
+		t.Fatalf("getRow %d: %v", id, err)
+	}
+	if leased.Valid {
+		r.LeasedUntil = &leased.Time
+	}
+	r.LastError = lastError.String
+	return r
+}
+
+// waitForStatus synchronizes on Run's async work; polls every 20ms
+// until status==want or timeout fires.
+func waitForStatus(t testing.TB, pool *pgxpool.Pool, id int64, want string, timeout time.Duration) testRow {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		r := getRow(t, pool, id)
+		if r.Status == want {
+			return r
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("row %d: status=%q after %s, want %q", id, r.Status, timeout, want)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/outbox/outbox_helpers_integration_test.go
+++ b/internal/outbox/outbox_helpers_integration_test.go
@@ -69,8 +69,17 @@ func insertRow(t testing.TB, pool *pgxpool.Pool, o insertOpts) int64 {
 		o.Status = "pending"
 	}
 
-	nextAt := pgtype.Timestamptz{Time: o.NextAttemptAt, Valid: !o.NextAttemptAt.IsZero()}
-	leased := pgtype.Timestamptz{Time: o.LeasedUntil, Valid: !o.LeasedUntil.IsZero()}
+	// pgx serializes time.Time as timestamptz; passing nil for an
+	// untyped `any` produces a SQL NULL. pgtype.Timestamptz round-trips
+	// less predictably here (the Valid=true case got reordered to NULL
+	// in observed runs).
+	var nextAt, leased any
+	if !o.NextAttemptAt.IsZero() {
+		nextAt = o.NextAttemptAt
+	}
+	if !o.LeasedUntil.IsZero() {
+		leased = o.LeasedUntil
+	}
 
 	const sql = `
 		INSERT INTO pgrelay_outbox (

--- a/internal/outbox/policy.go
+++ b/internal/outbox/policy.go
@@ -1,0 +1,49 @@
+package outbox
+
+import (
+	"math/rand/v2"
+	"sync"
+	"time"
+
+	"github.com/ronango/pgrelay/internal/config"
+)
+
+// Policy carries retry parameters plus a private RNG guarded by a
+// mutex. math/rand/v2's package-level helpers are race-safe but
+// share a single global Source, which makes test determinism
+// impossible — hence the seamed RNG.
+type Policy struct {
+	Base        time.Duration
+	Max         time.Duration
+	Jitter      float64
+	MaxAttempts int
+
+	mu  sync.Mutex
+	rng *rand.Rand
+}
+
+// NewPolicy builds a Policy with a time-seeded RNG.
+func NewPolicy(cfg config.Config) *Policy {
+	n := uint64(time.Now().UnixNano()) //nolint:gosec // non-crypto jitter
+	return NewPolicyWithRand(cfg, rand.New(rand.NewPCG(n, n^0x9E3779B97F4A7C15)))
+}
+
+// NewPolicyWithRand seams the RNG so tests can assert exact delays.
+func NewPolicyWithRand(cfg config.Config, rng *rand.Rand) *Policy {
+	return &Policy{
+		Base:        cfg.RetryBase,
+		Max:         cfg.RetryMax,
+		Jitter:      cfg.RetryJitter,
+		MaxAttempts: cfg.MaxAttempts,
+		rng:         rng,
+	}
+}
+
+// NextDelay returns the wait before the next attempt. attempt is the
+// row's `attempts` count after Claim's increment (so 1 on the first
+// retry). Safe for concurrent use.
+func (p *Policy) NextDelay(attempt int) time.Duration {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return Backoff(attempt, p.Base, p.Max, p.Jitter, p.rng)
+}

--- a/internal/outbox/policy_test.go
+++ b/internal/outbox/policy_test.go
@@ -1,0 +1,113 @@
+package outbox_test
+
+import (
+	"math/rand/v2"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ronango/pgrelay/internal/config"
+	"github.com/ronango/pgrelay/internal/outbox"
+)
+
+func testCfg() config.Config {
+	return config.Config{
+		RetryBase:   time.Second,
+		RetryMax:    time.Minute,
+		RetryJitter: 0.2,
+		MaxAttempts: 10,
+	}
+}
+
+func TestPolicy_NextDelayMatchesBackoffWithSameRNG(t *testing.T) {
+	cfg := testCfg()
+
+	// Two RNGs from identical seeds → Policy.NextDelay must produce
+	// the same sequence as a direct Backoff call.
+	rngPolicy := rand.New(rand.NewPCG(42, 0))
+	rngDirect := rand.New(rand.NewPCG(42, 0))
+	p := outbox.NewPolicyWithRand(cfg, rngPolicy)
+
+	for attempt := 1; attempt <= 5; attempt++ {
+		gotPolicy := p.NextDelay(attempt)
+		gotDirect := outbox.Backoff(attempt, cfg.RetryBase, cfg.RetryMax, cfg.RetryJitter, rngDirect)
+		if gotPolicy != gotDirect {
+			t.Errorf("attempt=%d: Policy.NextDelay=%s, direct Backoff=%s", attempt, gotPolicy, gotDirect)
+		}
+	}
+}
+
+func TestPolicy_NextDelayDeterministicAcrossSeededInstances(t *testing.T) {
+	cfg := testCfg()
+	p1 := outbox.NewPolicyWithRand(cfg, rand.New(rand.NewPCG(1, 2)))
+	p2 := outbox.NewPolicyWithRand(cfg, rand.New(rand.NewPCG(1, 2)))
+
+	for attempt := 1; attempt <= 8; attempt++ {
+		d1 := p1.NextDelay(attempt)
+		d2 := p2.NextDelay(attempt)
+		if d1 != d2 {
+			t.Errorf("attempt=%d: instances with same seed diverged: %s vs %s", attempt, d1, d2)
+		}
+	}
+}
+
+func TestPolicy_NextDelayConcurrentSafe(t *testing.T) {
+	// Run under `go test -race`; the RNG must be guarded.
+	cfg := testCfg()
+	p := outbox.NewPolicyWithRand(cfg, rand.New(rand.NewPCG(7, 11)))
+
+	const goroutines = 32
+	const callsEach = 200
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for i := 1; i <= callsEach; i++ {
+				_ = p.NextDelay(i)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func TestNewPolicy_NonDeterministicAcrossCalls(t *testing.T) {
+	// Catches the obvious regression of seeding from a constant. Two
+	// NewPolicy calls 1µs apart must produce divergent streams.
+	cfg := testCfg()
+	p1 := outbox.NewPolicy(cfg)
+	time.Sleep(time.Microsecond)
+	p2 := outbox.NewPolicy(cfg)
+
+	// Compare 5 attempts; collision across all 5 with independent seeds
+	// is astronomically unlikely.
+	allSame := true
+	for attempt := 1; attempt <= 5; attempt++ {
+		if p1.NextDelay(attempt) != p2.NextDelay(attempt) {
+			allSame = false
+			break
+		}
+	}
+	if allSame {
+		t.Error("two NewPolicy calls produced identical delays — RNG seeding likely broken")
+	}
+}
+
+func TestPolicy_FieldsMirrorConfig(t *testing.T) {
+	cfg := testCfg()
+	p := outbox.NewPolicy(cfg)
+
+	if p.Base != cfg.RetryBase {
+		t.Errorf("Base = %s, want %s", p.Base, cfg.RetryBase)
+	}
+	if p.Max != cfg.RetryMax {
+		t.Errorf("Max = %s, want %s", p.Max, cfg.RetryMax)
+	}
+	if p.Jitter != cfg.RetryJitter {
+		t.Errorf("Jitter = %v, want %v", p.Jitter, cfg.RetryJitter)
+	}
+	if p.MaxAttempts != cfg.MaxAttempts {
+		t.Errorf("MaxAttempts = %d, want %d", p.MaxAttempts, cfg.MaxAttempts)
+	}
+}

--- a/internal/outbox/primitives_integration_test.go
+++ b/internal/outbox/primitives_integration_test.go
@@ -1,0 +1,196 @@
+//go:build integration
+
+package outbox_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ronango/pgrelay/internal/outbox"
+	"github.com/ronango/pgrelay/internal/testdb"
+)
+
+func TestClaim_HappyPath(t *testing.T) {
+	pool := testdb.New(t)
+	id := insertRow(t, pool, insertOpts{})
+
+	const leaseDuration = 30 * time.Second
+	beforeClaim := time.Now()
+	rows, err := outbox.Claim(t.Context(), pool, 10, leaseDuration)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != id {
+		t.Fatalf("Claim returned %v, want [%d]", rows, id)
+	}
+	if rows[0].Attempts != 1 {
+		t.Errorf("Attempts = %d, want 1", rows[0].Attempts)
+	}
+	// Returned LeasedUntil must reflect the requested window.
+	if want := beforeClaim.Add(leaseDuration); rows[0].LeasedUntil.Before(want.Add(-time.Second)) {
+		t.Errorf("returned LeasedUntil = %s, want >= %s", rows[0].LeasedUntil, want)
+	}
+
+	r := getRow(t, pool, id)
+	if r.Status != "in_flight" || r.LeasedUntil == nil {
+		t.Fatalf("post-claim row = %+v, want in_flight with non-NULL leased_until", r)
+	}
+	if want := beforeClaim.Add(leaseDuration); r.LeasedUntil.Before(want.Add(-time.Second)) {
+		t.Errorf("on-disk LeasedUntil = %s, want >= %s", *r.LeasedUntil, want)
+	}
+}
+
+func TestClaim_TieBreaksByID(t *testing.T) {
+	// Two rows with the same next_attempt_at must dispatch in id order
+	// per Claim's ORDER BY next_attempt_at, id.
+	pool := testdb.New(t)
+	at := time.Now().Add(-time.Second)
+	idLow := insertRow(t, pool, insertOpts{NextAttemptAt: at})
+	idHigh := insertRow(t, pool, insertOpts{NextAttemptAt: at})
+
+	rows, err := outbox.Claim(t.Context(), pool, 10, time.Minute)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if len(rows) != 2 || rows[0].ID != idLow || rows[1].ID != idHigh {
+		t.Errorf("Claim order = %v, want [%d, %d]", rows, idLow, idHigh)
+	}
+}
+
+func TestClaim_RespectsNextAttemptAt(t *testing.T) {
+	pool := testdb.New(t)
+	insertRow(t, pool, insertOpts{NextAttemptAt: time.Now().Add(time.Hour)})
+
+	rows, err := outbox.Claim(t.Context(), pool, 10, time.Minute)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("Claim returned %d rows, want 0 (future next_attempt_at)", len(rows))
+	}
+}
+
+func TestClaim_LimitsBatchSize(t *testing.T) {
+	pool := testdb.New(t)
+	for range 5 {
+		insertRow(t, pool, insertOpts{})
+	}
+
+	rows, err := outbox.Claim(t.Context(), pool, 3, time.Minute)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("Claim returned %d rows, want 3 (batch cap)", len(rows))
+	}
+}
+
+func TestClaim_OrdersByNextAttemptThenID(t *testing.T) {
+	pool := testdb.New(t)
+
+	now := time.Now()
+	idLater := insertRow(t, pool, insertOpts{NextAttemptAt: now.Add(-100 * time.Millisecond)})
+	idEarlier := insertRow(t, pool, insertOpts{NextAttemptAt: now.Add(-time.Second)})
+
+	rows, err := outbox.Claim(t.Context(), pool, 10, time.Minute)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("Claim returned %d rows, want 2", len(rows))
+	}
+	if rows[0].ID != idEarlier || rows[1].ID != idLater {
+		t.Errorf("Claim order = [%d, %d], want [%d, %d] (older next_attempt_at first)",
+			rows[0].ID, rows[1].ID, idEarlier, idLater)
+	}
+}
+
+func TestClaim_SkipsLockedRows(t *testing.T) {
+	pool := testdb.New(t)
+	id1 := insertRow(t, pool, insertOpts{})
+	id2 := insertRow(t, pool, insertOpts{})
+
+	// Hold a row lock from a separate connection. The Claim's
+	// FOR UPDATE SKIP LOCKED must pass this row over to id2.
+	tx, err := pool.Begin(t.Context())
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+	if _, lockErr := tx.Exec(t.Context(),
+		`SELECT id FROM pgrelay_outbox WHERE id = $1 FOR UPDATE`, id1); lockErr != nil {
+		t.Fatalf("lock id1: %v", lockErr)
+	}
+
+	rows, err := outbox.Claim(t.Context(), pool, 10, time.Minute)
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != id2 {
+		t.Fatalf("Claim returned %v, want [%d] (id1 locked)", rows, id2)
+	}
+}
+
+func TestMarkSent_TransitionsAndClearsLease(t *testing.T) {
+	pool := testdb.New(t)
+	id := insertRow(t, pool, insertOpts{
+		Status:      "in_flight",
+		Attempts:    1,
+		LeasedUntil: time.Now().Add(30 * time.Second),
+	})
+
+	if err := outbox.MarkSent(t.Context(), pool, id); err != nil {
+		t.Fatalf("MarkSent: %v", err)
+	}
+	r := getRow(t, pool, id)
+	if r.Status != "sent" || r.LeasedUntil != nil || r.LastError != "" {
+		t.Errorf("post-MarkSent = %+v, want status=sent leased_until=NULL last_error=\"\"", r)
+	}
+}
+
+func TestMarkRetry_TransitionsAndRecordsError(t *testing.T) {
+	pool := testdb.New(t)
+	id := insertRow(t, pool, insertOpts{
+		Status:      "in_flight",
+		Attempts:    1,
+		LeasedUntil: time.Now().Add(30 * time.Second),
+	})
+
+	nextAt := time.Now().Add(5 * time.Minute).UTC()
+	if err := outbox.MarkRetry(t.Context(), pool, id, nextAt, "503 upstream"); err != nil {
+		t.Fatalf("MarkRetry: %v", err)
+	}
+
+	r := getRow(t, pool, id)
+	if r.Status != "pending" || r.LeasedUntil != nil {
+		t.Errorf("post-MarkRetry status = %q, leased_until = %v, want pending + NULL", r.Status, r.LeasedUntil)
+	}
+	if r.LastError != "503 upstream" {
+		t.Errorf("LastError = %q, want %q", r.LastError, "503 upstream")
+	}
+	// Truncate to seconds — TIMESTAMPTZ round-trip may shave sub-µs precision.
+	if !r.NextAttemptAt.Round(time.Second).Equal(nextAt.Round(time.Second)) {
+		t.Errorf("NextAttemptAt = %s, want %s", r.NextAttemptAt, nextAt)
+	}
+}
+
+func TestMarkDead_TransitionsAndRecordsError(t *testing.T) {
+	pool := testdb.New(t)
+	id := insertRow(t, pool, insertOpts{
+		Status:      "in_flight",
+		Attempts:    3,
+		LeasedUntil: time.Now().Add(30 * time.Second),
+	})
+
+	if err := outbox.MarkDead(t.Context(), pool, id, "400 Bad Request"); err != nil {
+		t.Fatalf("MarkDead: %v", err)
+	}
+	r := getRow(t, pool, id)
+	if r.Status != "dead" || r.LeasedUntil != nil {
+		t.Errorf("post-MarkDead status=%q leased_until=%v, want dead + NULL", r.Status, r.LeasedUntil)
+	}
+	if r.LastError != "400 Bad Request" {
+		t.Errorf("LastError = %q, want %q", r.LastError, "400 Bad Request")
+	}
+}

--- a/internal/outbox/retry.go
+++ b/internal/outbox/retry.go
@@ -1,0 +1,41 @@
+package outbox
+
+import (
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// Backoff returns the next-attempt delay for a row that just failed.
+// Formula: clamp(base * 2^(attempt-1), maxDelay) ± jitter*delay, then
+// re-clamp so jitter cannot push the result above maxDelay.
+//
+// attempt is the count *after* the failed dispatch (i.e. the outbox
+// row's `attempts` after Claim's increment). attempt < 1 is treated as
+// 1 so the first retry waits `base`. base <= 0 returns 0 immediately —
+// "no backoff" semantics rather than silently saturating to maxDelay.
+// maxDelay <= 0 likewise returns 0. jitter <= 0 and NaN disable
+// jitter; jitter > 1 widens swings and any negative excursion is
+// clamped to 0 by the final non-negative guard.
+func Backoff(attempt int, base, maxDelay time.Duration, jitter float64) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	if attempt < 1 {
+		attempt = 1
+	}
+
+	// float64 path so huge `attempt` values can't silently wrap int64;
+	// +Inf naturally fails the `<` clamp below and falls through to maxDelay.
+	delayF := float64(base) * math.Pow(2, float64(attempt-1))
+	delay := maxDelay
+	if delayF < float64(maxDelay) {
+		delay = time.Duration(delayF)
+	}
+
+	if jitter > 0 {
+		factor := 1 + jitter*(2*rand.Float64()-1) // [-jitter, +jitter] around 1
+		delay = min(time.Duration(float64(delay)*factor), maxDelay)
+	}
+	return max(delay, 0)
+}

--- a/internal/outbox/retry.go
+++ b/internal/outbox/retry.go
@@ -6,18 +6,16 @@ import (
 	"time"
 )
 
-// Backoff returns the next-attempt delay for a row that just failed.
-// Formula: clamp(base * 2^(attempt-1), maxDelay) ± jitter*delay, then
-// re-clamp so jitter cannot push the result above maxDelay.
+// Backoff returns the next-attempt delay: clamp(base * 2^(attempt-1),
+// maxDelay) ± jitter*delay, re-clamped so jitter can't exceed maxDelay.
 //
-// attempt is the count *after* the failed dispatch (i.e. the outbox
-// row's `attempts` after Claim's increment). attempt < 1 is treated as
-// 1 so the first retry waits `base`. base <= 0 returns 0 immediately —
-// "no backoff" semantics rather than silently saturating to maxDelay.
-// maxDelay <= 0 likewise returns 0. jitter <= 0 and NaN disable
-// jitter; jitter > 1 widens swings and any negative excursion is
-// clamped to 0 by the final non-negative guard.
-func Backoff(attempt int, base, maxDelay time.Duration, jitter float64) time.Duration {
+// Edge cases (semantic, not derivable from the formula):
+//   - attempt < 1 treated as 1 (first retry waits `base`).
+//   - base <= 0 or maxDelay <= 0 returns 0 ("no backoff", not saturate).
+//   - jitter <= 0 or NaN disables jitter; jitter > 1 widens swings and
+//     any negative excursion is clamped to 0.
+//   - rng may be nil when jitter <= 0; required otherwise.
+func Backoff(attempt int, base, maxDelay time.Duration, jitter float64, rng *rand.Rand) time.Duration {
 	if base <= 0 {
 		return 0
 	}
@@ -25,8 +23,8 @@ func Backoff(attempt int, base, maxDelay time.Duration, jitter float64) time.Dur
 		attempt = 1
 	}
 
-	// float64 path so huge `attempt` values can't silently wrap int64;
-	// +Inf naturally fails the `<` clamp below and falls through to maxDelay.
+	// float64 keeps huge `attempt` from wrapping int64; +Inf fails the
+	// `<` below and falls through to maxDelay.
 	delayF := float64(base) * math.Pow(2, float64(attempt-1))
 	delay := maxDelay
 	if delayF < float64(maxDelay) {
@@ -34,7 +32,8 @@ func Backoff(attempt int, base, maxDelay time.Duration, jitter float64) time.Dur
 	}
 
 	if jitter > 0 {
-		factor := 1 + jitter*(2*rand.Float64()-1) // [-jitter, +jitter] around 1
+		// 2x-1 maps Float64's [0,1) to [-1,1).
+		factor := 1 + jitter*(2*rng.Float64()-1)
 		delay = min(time.Duration(float64(delay)*factor), maxDelay)
 	}
 	return max(delay, 0)

--- a/internal/outbox/retry_test.go
+++ b/internal/outbox/retry_test.go
@@ -1,0 +1,134 @@
+package outbox_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ronango/pgrelay/internal/outbox"
+)
+
+func TestBackoff_ExponentialNoJitter(t *testing.T) {
+	base := time.Second
+	maxDelay := time.Hour // big enough that no clamp fires for these attempts
+
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, time.Second},        // 2^0 * 1s
+		{2, 2 * time.Second},    // 2^1 * 1s
+		{3, 4 * time.Second},    // 2^2 * 1s
+		{4, 8 * time.Second},    // 2^3 * 1s
+		{10, 512 * time.Second}, // 2^9 * 1s = 8m32s
+	}
+	for _, tc := range cases {
+		got := outbox.Backoff(tc.attempt, base, maxDelay, 0)
+		if got != tc.want {
+			t.Errorf("Backoff(attempt=%d) = %s, want %s", tc.attempt, got, tc.want)
+		}
+	}
+}
+
+func TestBackoff_ClampsToMax(t *testing.T) {
+	base := time.Second
+	maxDelay := 5 * time.Minute
+
+	// 2^9 = 512s = 8m32s > 5m → clamped.
+	if got := outbox.Backoff(10, base, maxDelay, 0); got != maxDelay {
+		t.Errorf("Backoff(10, 1s, 5m, 0) = %s, want %s (clamped)", got, maxDelay)
+	}
+	// attempt=100 — huge but finite float64; clamped via the `<` check.
+	if got := outbox.Backoff(100, base, maxDelay, 0); got != maxDelay {
+		t.Errorf("Backoff(100, ...) = %s, want %s (huge but finite, clamped)", got, maxDelay)
+	}
+	// attempt=2000 — math.Pow(2, 1999) overflows to +Inf; still clamped
+	// because Inf is not less than any finite maxDelay.
+	if got := outbox.Backoff(2000, base, maxDelay, 0); got != maxDelay {
+		t.Errorf("Backoff(2000, ...) = %s, want %s (+Inf clamped)", got, maxDelay)
+	}
+}
+
+func TestBackoff_NonPositiveBaseReturnsZero(t *testing.T) {
+	for _, base := range []time.Duration{0, -time.Second, -time.Hour} {
+		if got := outbox.Backoff(3, base, time.Minute, 0); got != 0 {
+			t.Errorf("Backoff(3, %s, ...) = %s, want 0 (no-backoff semantics)", base, got)
+		}
+	}
+}
+
+func TestBackoff_NonPositiveMaxReturnsZero(t *testing.T) {
+	for _, maxDelay := range []time.Duration{0, -time.Second} {
+		if got := outbox.Backoff(3, time.Second, maxDelay, 0); got != 0 {
+			t.Errorf("Backoff(3, 1s, %s, 0) = %s, want 0", maxDelay, got)
+		}
+	}
+}
+
+func TestBackoff_JitterCannotExceedMax(t *testing.T) {
+	const trials = 500
+	// attempt=20 → 2^19 * 1s ≫ maxDelay, so pre-jitter delay == maxDelay.
+	// With factor up to 1+jitter the unclamped product would exceed maxDelay;
+	// the re-clamp must cap it.
+	base := time.Second
+	maxDelay := 10 * time.Second
+	jitter := 0.5
+
+	for range trials {
+		got := outbox.Backoff(20, base, maxDelay, jitter)
+		if got > maxDelay {
+			t.Fatalf("Backoff exceeded maxDelay: got %s, max %s", got, maxDelay)
+		}
+		if got < 0 {
+			t.Fatalf("Backoff went negative: %s", got)
+		}
+	}
+}
+
+func TestBackoff_TreatsZeroOrNegativeAttemptAsFirst(t *testing.T) {
+	base := 500 * time.Millisecond
+	maxDelay := time.Minute
+
+	for _, attempt := range []int{0, -1, -100} {
+		got := outbox.Backoff(attempt, base, maxDelay, 0)
+		if got != base {
+			t.Errorf("Backoff(%d) = %s, want %s (clamped to attempt=1)", attempt, got, base)
+		}
+	}
+}
+
+func TestBackoff_JitterStaysWithinBand(t *testing.T) {
+	const trials = 200
+	base := time.Second
+	maxDelay := time.Minute
+	jitter := 0.2
+
+	// attempt=2 → 2s. With ±20% jitter: [1.6s, 2.4s].
+	const wantCenter = 2 * time.Second
+	low := time.Duration(float64(wantCenter) * (1 - jitter))
+	high := time.Duration(float64(wantCenter) * (1 + jitter))
+
+	var sum time.Duration
+	for range trials {
+		got := outbox.Backoff(2, base, maxDelay, jitter)
+		if got < low || got > high {
+			t.Errorf("Backoff with jitter = %s, want in [%s, %s]", got, low, high)
+		}
+		sum += got
+	}
+	mean := sum / trials
+	tolerance := time.Duration(float64(wantCenter) * 0.1)
+	if mean < wantCenter-tolerance || mean > wantCenter+tolerance {
+		t.Errorf("mean across %d trials = %s, want roughly %s ±%s", trials, mean, wantCenter, tolerance)
+	}
+}
+
+func TestBackoff_ZeroJitterIsDeterministic(t *testing.T) {
+	base := time.Second
+	maxDelay := time.Minute
+
+	got1 := outbox.Backoff(3, base, maxDelay, 0)
+	got2 := outbox.Backoff(3, base, maxDelay, 0)
+	if got1 != got2 {
+		t.Errorf("Backoff with jitter=0 not deterministic: %s vs %s", got1, got2)
+	}
+}

--- a/internal/outbox/retry_test.go
+++ b/internal/outbox/retry_test.go
@@ -1,11 +1,18 @@
 package outbox_test
 
 import (
+	"math/rand/v2"
 	"testing"
 	"time"
 
 	"github.com/ronango/pgrelay/internal/outbox"
 )
+
+// newRNG returns a deterministic *rand.Rand. Fixed seeds so jitter
+// tests are reproducible across runs and across CPUs.
+func newRNG() *rand.Rand {
+	return rand.New(rand.NewPCG(0x9E3779B97F4A7C15, 0xBB67AE8584CAA73B))
+}
 
 func TestBackoff_ExponentialNoJitter(t *testing.T) {
 	base := time.Second
@@ -22,7 +29,7 @@ func TestBackoff_ExponentialNoJitter(t *testing.T) {
 		{10, 512 * time.Second}, // 2^9 * 1s = 8m32s
 	}
 	for _, tc := range cases {
-		got := outbox.Backoff(tc.attempt, base, maxDelay, 0)
+		got := outbox.Backoff(tc.attempt, base, maxDelay, 0, nil)
 		if got != tc.want {
 			t.Errorf("Backoff(attempt=%d) = %s, want %s", tc.attempt, got, tc.want)
 		}
@@ -34,23 +41,23 @@ func TestBackoff_ClampsToMax(t *testing.T) {
 	maxDelay := 5 * time.Minute
 
 	// 2^9 = 512s = 8m32s > 5m → clamped.
-	if got := outbox.Backoff(10, base, maxDelay, 0); got != maxDelay {
+	if got := outbox.Backoff(10, base, maxDelay, 0, nil); got != maxDelay {
 		t.Errorf("Backoff(10, 1s, 5m, 0) = %s, want %s (clamped)", got, maxDelay)
 	}
 	// attempt=100 — huge but finite float64; clamped via the `<` check.
-	if got := outbox.Backoff(100, base, maxDelay, 0); got != maxDelay {
+	if got := outbox.Backoff(100, base, maxDelay, 0, nil); got != maxDelay {
 		t.Errorf("Backoff(100, ...) = %s, want %s (huge but finite, clamped)", got, maxDelay)
 	}
 	// attempt=2000 — math.Pow(2, 1999) overflows to +Inf; still clamped
 	// because Inf is not less than any finite maxDelay.
-	if got := outbox.Backoff(2000, base, maxDelay, 0); got != maxDelay {
+	if got := outbox.Backoff(2000, base, maxDelay, 0, nil); got != maxDelay {
 		t.Errorf("Backoff(2000, ...) = %s, want %s (+Inf clamped)", got, maxDelay)
 	}
 }
 
 func TestBackoff_NonPositiveBaseReturnsZero(t *testing.T) {
 	for _, base := range []time.Duration{0, -time.Second, -time.Hour} {
-		if got := outbox.Backoff(3, base, time.Minute, 0); got != 0 {
+		if got := outbox.Backoff(3, base, time.Minute, 0, nil); got != 0 {
 			t.Errorf("Backoff(3, %s, ...) = %s, want 0 (no-backoff semantics)", base, got)
 		}
 	}
@@ -58,7 +65,7 @@ func TestBackoff_NonPositiveBaseReturnsZero(t *testing.T) {
 
 func TestBackoff_NonPositiveMaxReturnsZero(t *testing.T) {
 	for _, maxDelay := range []time.Duration{0, -time.Second} {
-		if got := outbox.Backoff(3, time.Second, maxDelay, 0); got != 0 {
+		if got := outbox.Backoff(3, time.Second, maxDelay, 0, nil); got != 0 {
 			t.Errorf("Backoff(3, 1s, %s, 0) = %s, want 0", maxDelay, got)
 		}
 	}
@@ -72,9 +79,10 @@ func TestBackoff_JitterCannotExceedMax(t *testing.T) {
 	base := time.Second
 	maxDelay := 10 * time.Second
 	jitter := 0.5
+	rng := newRNG()
 
 	for range trials {
-		got := outbox.Backoff(20, base, maxDelay, jitter)
+		got := outbox.Backoff(20, base, maxDelay, jitter, rng)
 		if got > maxDelay {
 			t.Fatalf("Backoff exceeded maxDelay: got %s, max %s", got, maxDelay)
 		}
@@ -89,7 +97,7 @@ func TestBackoff_TreatsZeroOrNegativeAttemptAsFirst(t *testing.T) {
 	maxDelay := time.Minute
 
 	for _, attempt := range []int{0, -1, -100} {
-		got := outbox.Backoff(attempt, base, maxDelay, 0)
+		got := outbox.Backoff(attempt, base, maxDelay, 0, nil)
 		if got != base {
 			t.Errorf("Backoff(%d) = %s, want %s (clamped to attempt=1)", attempt, got, base)
 		}
@@ -101,6 +109,7 @@ func TestBackoff_JitterStaysWithinBand(t *testing.T) {
 	base := time.Second
 	maxDelay := time.Minute
 	jitter := 0.2
+	rng := newRNG()
 
 	// attempt=2 → 2s. With ±20% jitter: [1.6s, 2.4s].
 	const wantCenter = 2 * time.Second
@@ -109,7 +118,7 @@ func TestBackoff_JitterStaysWithinBand(t *testing.T) {
 
 	var sum time.Duration
 	for range trials {
-		got := outbox.Backoff(2, base, maxDelay, jitter)
+		got := outbox.Backoff(2, base, maxDelay, jitter, rng)
 		if got < low || got > high {
 			t.Errorf("Backoff with jitter = %s, want in [%s, %s]", got, low, high)
 		}
@@ -122,12 +131,30 @@ func TestBackoff_JitterStaysWithinBand(t *testing.T) {
 	}
 }
 
+func TestBackoff_DeterministicWithSeededRNG(t *testing.T) {
+	base := time.Second
+	maxDelay := time.Minute
+	jitter := 0.3
+
+	// Two independent RNGs with the same seed must produce identical
+	// sequences — this is what lets Policy tests assert exact delays.
+	rng1 := newRNG()
+	rng2 := newRNG()
+	for attempt := 1; attempt <= 5; attempt++ {
+		got1 := outbox.Backoff(attempt, base, maxDelay, jitter, rng1)
+		got2 := outbox.Backoff(attempt, base, maxDelay, jitter, rng2)
+		if got1 != got2 {
+			t.Errorf("attempt=%d not reproducible across seeded RNGs: %s vs %s", attempt, got1, got2)
+		}
+	}
+}
+
 func TestBackoff_ZeroJitterIsDeterministic(t *testing.T) {
 	base := time.Second
 	maxDelay := time.Minute
 
-	got1 := outbox.Backoff(3, base, maxDelay, 0)
-	got2 := outbox.Backoff(3, base, maxDelay, 0)
+	got1 := outbox.Backoff(3, base, maxDelay, 0, nil)
+	got2 := outbox.Backoff(3, base, maxDelay, 0, nil)
 	if got1 != got2 {
 		t.Errorf("Backoff with jitter=0 not deterministic: %s vs %s", got1, got2)
 	}

--- a/internal/outbox/row.go
+++ b/internal/outbox/row.go
@@ -1,0 +1,84 @@
+// Package outbox is the dispatcher worker: claim pending rows under a
+// lease, deliver via a sinks.Sink, mark sent / retry / dead, and reclaim
+// orphaned in-flight rows when leases expire.
+package outbox
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// Row mirrors a pgrelay_outbox row. Nullable columns surface as zero
+// values; the dispatcher only reads them when status guarantees presence
+// (e.g. LeasedUntil after Claim, SentAt never read after MarkSent).
+//
+// Headers is map[string]string by contract with sinks.Message: producer
+// writes single-valued headers to the outbox.headers JSONB object;
+// outbound webhook delivery doesn't surface multi-valued forms.
+type Row struct {
+	ID            int64
+	AggregateType string
+	AggregateID   string
+	EventType     string
+	Payload       []byte
+	Headers       map[string]string
+	Traceparent   string
+	Tracestate    string
+	Sink          string
+	Destination   string
+	Status        string
+	Attempts      int
+	NextAttemptAt time.Time
+	LeasedUntil   time.Time
+	LastError     string
+	CreatedAt     time.Time
+	SentAt        time.Time
+}
+
+// rowColumns is the SELECT/RETURNING column list shared by every query
+// that produces a Row. Order matches scanRow.
+const rowColumns = `
+	id, aggregate_type, aggregate_id, event_type, payload, headers,
+	traceparent, tracestate, sink, destination, status, attempts,
+	next_attempt_at, leased_until, last_error, created_at, sent_at
+`
+
+func scanRow(rec pgx.CollectableRow) (Row, error) {
+	var r Row
+	var headersJSON []byte
+	var traceparent, tracestate, lastError pgtype.Text
+	var leasedUntil, sentAt pgtype.Timestamptz
+
+	if err := rec.Scan(
+		&r.ID, &r.AggregateType, &r.AggregateID, &r.EventType,
+		&r.Payload, &headersJSON,
+		&traceparent, &tracestate,
+		&r.Sink, &r.Destination,
+		&r.Status, &r.Attempts,
+		&r.NextAttemptAt, &leasedUntil,
+		&lastError,
+		&r.CreatedAt, &sentAt,
+	); err != nil {
+		return Row{}, err
+	}
+
+	r.Traceparent = traceparent.String
+	r.Tracestate = tracestate.String
+	r.LastError = lastError.String
+	if leasedUntil.Valid {
+		r.LeasedUntil = leasedUntil.Time
+	}
+	if sentAt.Valid {
+		r.SentAt = sentAt.Time
+	}
+	if len(headersJSON) > 0 {
+		if err := json.Unmarshal(headersJSON, &r.Headers); err != nil {
+			return Row{}, fmt.Errorf("unmarshal headers for row %d: %w", r.ID, err)
+		}
+	}
+	return r, nil
+}

--- a/internal/outbox/state_collector_integration_test.go
+++ b/internal/outbox/state_collector_integration_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+
+package outbox_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/ronango/pgrelay/internal/outbox"
+	"github.com/ronango/pgrelay/internal/testdb"
+)
+
+func TestStateCollector_EmptyTable(t *testing.T) {
+	pool := testdb.New(t)
+	reg := prometheus.NewRegistry()
+	outbox.RegisterStateCollector(reg, pool, quietLogger())
+
+	if got := collectGauge(t, reg, "pgrelay_outbox_backlog_seconds", nil); got != 0 {
+		t.Errorf("backlog = %v, want 0", got)
+	}
+	for _, status := range []string{"pending", "in_flight"} {
+		if got := collectGauge(t, reg, "pgrelay_outbox_rows", map[string]string{"status": status}); got != 0 {
+			t.Errorf("rows{status=%q} = %v, want 0", status, got)
+		}
+	}
+}
+
+func TestStateCollector_CountsAndBacklog(t *testing.T) {
+	pool := testdb.New(t)
+
+	// Oldest pending row anchored 10 minutes in the past so backlog
+	// assertion has comfortable headroom over container clock jitter.
+	insertRow(t, pool, insertOpts{Status: "pending", NextAttemptAt: time.Now().Add(-10 * time.Minute)})
+	insertRow(t, pool, insertOpts{Status: "pending", NextAttemptAt: time.Now().Add(-5 * time.Second)})
+	// Future pending must NOT count toward backlog.
+	insertRow(t, pool, insertOpts{Status: "pending", NextAttemptAt: time.Now().Add(time.Hour)})
+
+	insertRow(t, pool, insertOpts{
+		Status: "in_flight", Attempts: 1,
+		LeasedUntil: time.Now().Add(time.Minute),
+	})
+	insertRow(t, pool, insertOpts{Status: "sent"})
+	insertRow(t, pool, insertOpts{Status: "dead"})
+
+	reg := prometheus.NewRegistry()
+	outbox.RegisterStateCollector(reg, pool, quietLogger())
+
+	if got := collectGauge(t, reg, "pgrelay_outbox_rows", map[string]string{"status": "pending"}); got != 3 {
+		t.Errorf("rows{pending} = %v, want 3", got)
+	}
+	if got := collectGauge(t, reg, "pgrelay_outbox_rows", map[string]string{"status": "in_flight"}); got != 1 {
+		t.Errorf("rows{in_flight} = %v, want 1", got)
+	}
+
+	if got := collectGauge(t, reg, "pgrelay_outbox_backlog_seconds", nil); got < 60 {
+		t.Errorf("backlog = %v, want >= 60s (oldest pending was 10m ago)", got)
+	}
+}
+
+// collectGauge fails the test if the metric is absent.
+func collectGauge(t testing.TB, reg *prometheus.Registry, name string, labels map[string]string) float64 {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			if matchLabels(m.GetLabel(), labels) {
+				return m.GetGauge().GetValue()
+			}
+		}
+	}
+	t.Fatalf("metric %q with labels %v not found", name, labels)
+	return 0
+}
+
+func matchLabels(got []*dto.LabelPair, want map[string]string) bool {
+	if len(want) == 0 {
+		return len(got) == 0
+	}
+	if len(got) != len(want) {
+		return false
+	}
+	for _, l := range got {
+		if want[l.GetName()] != l.GetValue() {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/outbox/status.go
+++ b/internal/outbox/status.go
@@ -1,0 +1,61 @@
+package outbox
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// MarkSent transitions a claimed row to status='sent'. Caller invokes
+// after sink.Send returns nil.
+func MarkSent(ctx context.Context, pool *pgxpool.Pool, id int64) error {
+	_, err := pool.Exec(ctx, `
+		UPDATE pgrelay_outbox
+		SET status = 'sent',
+		    sent_at = now(),
+		    leased_until = NULL,
+		    last_error = NULL
+		WHERE id = $1
+	`, id)
+	if err != nil {
+		return fmt.Errorf("mark sent %d: %w", id, err)
+	}
+	return nil
+}
+
+// MarkRetry returns a claimed row to status='pending' with a future
+// next_attempt_at (computed by the caller's backoff policy) and records
+// the last error so operators can diagnose without grepping logs.
+func MarkRetry(ctx context.Context, pool *pgxpool.Pool, id int64, nextAttemptAt time.Time, lastError string) error {
+	_, err := pool.Exec(ctx, `
+		UPDATE pgrelay_outbox
+		SET status = 'pending',
+		    next_attempt_at = $2,
+		    last_error = $3,
+		    leased_until = NULL
+		WHERE id = $1
+	`, id, nextAttemptAt, lastError)
+	if err != nil {
+		return fmt.Errorf("mark retry %d: %w", id, err)
+	}
+	return nil
+}
+
+// MarkDead permanently transitions a row to status='dead'. Caller
+// invokes on terminal sink errors (4xx) or when attempts exceeds
+// MaxAttempts. Dead rows are not redispatched.
+func MarkDead(ctx context.Context, pool *pgxpool.Pool, id int64, lastError string) error {
+	_, err := pool.Exec(ctx, `
+		UPDATE pgrelay_outbox
+		SET status = 'dead',
+		    last_error = $2,
+		    leased_until = NULL
+		WHERE id = $1
+	`, id, lastError)
+	if err != nil {
+		return fmt.Errorf("mark dead %d: %w", id, err)
+	}
+	return nil
+}

--- a/internal/outbox/sweep.go
+++ b/internal/outbox/sweep.go
@@ -1,0 +1,38 @@
+package outbox
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ReclaimOrphans returns to 'pending' any in_flight row whose lease has
+// expired. Safety net for dispatchers that crashed or hung mid-dispatch.
+//
+// attempts is intentionally not re-incremented (Claim already counted
+// the dispatch); next_attempt_at is left alone because it was set by
+// the prior MarkRetry (or insert) and is already in the past from
+// pending's perspective. last_error is overwritten with a sentinel so
+// operators can distinguish lease expiry from sink failures.
+//
+// `leased_until IS NULL` is included to catch the pathological case
+// where an in_flight row somehow lost its lease — Claim always sets
+// one, so this shouldn't happen, but a stuck-forever row is the worst
+// failure mode and worth one extra OR.
+//
+// Returns the number of rows reclaimed.
+func ReclaimOrphans(ctx context.Context, pool *pgxpool.Pool) (int64, error) {
+	tag, err := pool.Exec(ctx, `
+		UPDATE pgrelay_outbox
+		SET status = 'pending',
+		    leased_until = NULL,
+		    last_error = 'lease expired'
+		WHERE status = 'in_flight'
+		  AND (leased_until IS NULL OR leased_until < now())
+	`)
+	if err != nil {
+		return 0, fmt.Errorf("reclaim orphans: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}

--- a/internal/outbox/sweep_integration_test.go
+++ b/internal/outbox/sweep_integration_test.go
@@ -1,0 +1,92 @@
+//go:build integration
+
+package outbox_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ronango/pgrelay/internal/outbox"
+	"github.com/ronango/pgrelay/internal/testdb"
+)
+
+func TestReclaimOrphans_ExpiredLease(t *testing.T) {
+	pool := testdb.New(t)
+	id := insertRow(t, pool, insertOpts{
+		Status:      "in_flight",
+		Attempts:    2,
+		LeasedUntil: time.Now().Add(-5 * time.Second),
+	})
+
+	n, err := outbox.ReclaimOrphans(t.Context(), pool)
+	if err != nil {
+		t.Fatalf("ReclaimOrphans: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("reclaimed = %d, want 1", n)
+	}
+
+	r := getRow(t, pool, id)
+	if r.Status != "pending" || r.LeasedUntil != nil {
+		t.Errorf("post-reclaim row = %+v, want pending + NULL lease", r)
+	}
+	if r.LastError != "lease expired" {
+		t.Errorf("LastError = %q, want %q", r.LastError, "lease expired")
+	}
+	if r.Attempts != 2 {
+		t.Errorf("Attempts = %d, want 2 (not re-incremented)", r.Attempts)
+	}
+}
+
+func TestReclaimOrphans_NullLease(t *testing.T) {
+	// Pathological case: in_flight row with no lease. Claim always
+	// sets one, so this shouldn't happen — sweeper recovers anyway.
+	pool := testdb.New(t)
+	id := insertRow(t, pool, insertOpts{Status: "in_flight", Attempts: 1})
+
+	n, err := outbox.ReclaimOrphans(t.Context(), pool)
+	if err != nil {
+		t.Fatalf("ReclaimOrphans: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("reclaimed = %d, want 1", n)
+	}
+	if r := getRow(t, pool, id); r.Status != "pending" {
+		t.Errorf("status = %q, want pending", r.Status)
+	}
+}
+
+func TestReclaimOrphans_LiveLeaseLeftAlone(t *testing.T) {
+	pool := testdb.New(t)
+	id := insertRow(t, pool, insertOpts{
+		Status:      "in_flight",
+		Attempts:    1,
+		LeasedUntil: time.Now().Add(time.Minute),
+	})
+
+	n, err := outbox.ReclaimOrphans(t.Context(), pool)
+	if err != nil {
+		t.Fatalf("ReclaimOrphans: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("reclaimed = %d, want 0", n)
+	}
+	if r := getRow(t, pool, id); r.Status != "in_flight" {
+		t.Errorf("status = %q, want in_flight", r.Status)
+	}
+}
+
+func TestReclaimOrphans_IgnoresOtherStatuses(t *testing.T) {
+	pool := testdb.New(t)
+	insertRow(t, pool, insertOpts{Status: "pending"})
+	insertRow(t, pool, insertOpts{Status: "sent"})
+	insertRow(t, pool, insertOpts{Status: "dead"})
+
+	n, err := outbox.ReclaimOrphans(t.Context(), pool)
+	if err != nil {
+		t.Fatalf("ReclaimOrphans: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("reclaimed = %d, want 0 (no in_flight rows)", n)
+	}
+}


### PR DESCRIPTION
Closes #6.

Implements the issue's acceptance criteria — concurrency-safe Claim with FOR UPDATE SKIP LOCKED + lease, full dispatch loop with metrics, exponential backoff + jitter, lease sweeper, and integration coverage across PG 14/15/16/17. Notes cover only divergence and additions beyond issue scope.

## Diverged from issue scope

- **Metric naming and split.** Issue's catalog used `pgrelay_outbox_dispatched_total` / `_retry_total` as separate counters and `_lag_seconds` / `_pending` / `_in_flight` / `_dead` as separate gauges. Shipped:
  - `pgrelay_outbox_attempts_total{result="sent|retry|dead"}` — single CounterVec. "Dispatched" wasn't quite right because retry isn't terminal; "attempts" is honest about what each increment represents (sum across labels = total work including retries). Help text spells this out.
  - `pgrelay_outbox_rows{status="pending|in_flight"}` — single GaugeVec. `dead` dropped from the live gauge because the table has no covering index for it; operators can `SELECT count(*) WHERE status='dead'` for triage. Documented in the metric Help.
  - `pgrelay_outbox_backlog_seconds` (renamed from `_lag_seconds`) — name made unambiguous: it's the age of the oldest pending row past its `next_attempt_at`, not raw row age.
- **`_claim_duration_seconds` and `_batch_size` histograms not emitted.** The dispatcher's per-row latency is already in `_dispatch_duration_seconds{sink}`; per-batch claim timing is observable via the pgx `_db_query_duration_seconds{op="query"}` histogram from #3 (the Claim UPDATE flows through that tracer). Adding duplicates would inflate cardinality for no signal. Open to reconsidering if benchmarks show otherwise in v0.2.
- **Retry-After is a floor, not an override.** Issue said server hint **overrides** policy backoff. Shipped as `min(max(policy.NextDelay, RetryAfter), policy.Max)` — server hint raises the floor when it's longer than the computed backoff, but never lowers (a server returning `Retry-After: 0` shouldn't busy-loop the dispatcher), and never escapes the operator-configured ceiling (a misbehaving origin shouldn't park rows past `RetryMax`).
- **Lease sweeper as in-process ticker, not separate goroutine.** Issue described "separate goroutine sweeps". Shipped as a second `select` arm inside `Run`'s loop, ticking at `LeaseDuration/2`. Net effect identical (independent cadence from poll); avoids a second goroutine + cancellation handshake.

## Added beyond issue scope

- **`Policy` struct with caller-owned seeded `*rand.Rand`** (`internal/outbox/policy.go`). `math/rand/v2`'s package-level helpers are race-safe but share one global Source, which made test determinism impossible — Policy seams the RNG via `NewPolicyWithRand` so tests can pin exact delays.
- **`Backoff` signature now takes `*rand.Rand`** (`internal/outbox/retry.go`). Pure-function form unchanged otherwise; Policy is its only in-tree caller.
- **`context.WithoutCancel` + 5s timeout for terminal status writes** (`dispatcher.go:dispatch`). MarkSent/Dead/Retry run on a detached context so a clean shutdown still persists the row's outcome instead of leaking it back to the sweeper. The matching contract: when `sink.Send` itself returns `ctx.Canceled`/`DeadlineExceeded` the row is **not** marked terminal — we don't know if the request reached the sink, so the lease sweeper owns recovery (`fix(outbox): keep row in_flight on shutdown mid-Send`, separate commit on this PR).
- **`stateCollector` is Prometheus-Collector-on-scrape**, not a background gauge-updater. One SQL `FILTER` aggregate per scrape (3s timeout headroom under Prom's 10s default), no goroutine, no stale data. Query plan uses BitmapOr over the existing partial indexes from #2.
- **`fix(outbox): keep row in_flight on shutdown mid-Send` shipped as its own commit on this PR.** Caught during the integration-test review pass: the original code marked a row `dead` with `last_error="context canceled"` when shutdown raced Send, breaking the at-least-once contract.
- **Concurrency-safe Claim is exercised structurally**, not via "10 dispatchers vs 1000 rows" stress. `TestClaim_SkipsLockedRows` holds an external `FOR UPDATE` from a second transaction and asserts Claim skips that row to the next id — proves the SKIP LOCKED semantics that the multi-dispatcher case relies on, without spinning up 10 goroutines for an N=1000 random shuffle. v0.2 benchmarks will exercise the higher-N case.

## Verification

- `make build / test / lint / vuln` — green locally with Go 1.25.10 (host can't run integration tests due to a known testcontainers + Fedora 43 netfilter issue; CI exercises them on a Linux runner).
- CI on this PR: `floor`, `golangci-lint`, `govulncheck`, `unit (1.25)`, `integration (14/15/16/17)`.