### PR TITLE
feat(cli): pgrelay binary — run, migrate, version

### DIFF
--- a/cmd/pgrelay/cli_integration_test.go
+++ b/cmd/pgrelay/cli_integration_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+
+package main
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ronango/pgrelay/internal/testdb"
+)
+
+// TestCLI_Version exercises the version subcommand end-to-end so the
+// binary's main → cli wiring + ldflags fallback to runtime/debug VCS
+// info both prove out. Unit tests cover versionString() directly.
+func TestCLI_Version(t *testing.T) {
+	res := runArgs(t, nil, "version")
+	if res.err != nil {
+		t.Fatalf("pgrelay version: %v\nstderr: %s", res.err, res.stderr)
+	}
+	for _, want := range []string{"pgrelay", runtime.Version()} {
+		if !strings.Contains(res.stdout, want) {
+			t.Errorf("stdout = %q, missing %q", res.stdout, want)
+		}
+	}
+}
+
+func TestCLI_MigrateLifecycle(t *testing.T) {
+	// testdb.New applies migrations on construction; we re-use its DSN
+	// to exercise the migrate subcommand's status + down paths against
+	// a real PG with the schema already in place.
+	pool := testdb.New(t)
+	dsn := pool.Config().ConnString()
+	env := []string{"PGRELAY_DATABASE_URL=" + dsn}
+
+	// status reflects the migrations testdb applied.
+	if res := runArgs(t, env, "migrate", "status"); res.err != nil ||
+		!strings.Contains(res.stdout, "version=") {
+		t.Fatalf("migrate status: err=%v stdout=%q stderr=%q", res.err, res.stdout, res.stderr)
+	}
+
+	// down without --yes must refuse — fat-finger guard.
+	res := runArgs(t, env, "migrate", "down")
+	if res.err == nil {
+		t.Fatalf("migrate down without --yes succeeded; want error\nstdout=%q", res.stdout)
+	}
+	if !strings.Contains(res.stderr, "--yes") {
+		t.Errorf("migrate down stderr = %q, want mention of --yes", res.stderr)
+	}
+
+	// down with --yes rolls back one step.
+	if res := runArgs(t, env, "migrate", "down", "--yes"); res.err != nil {
+		t.Fatalf("migrate down --yes: %v\nstderr: %s", res.err, res.stderr)
+	}
+
+	// up re-applies; idempotent on the second invocation (ErrNoChange
+	// is swallowed in migrateUpAction).
+	if res := runArgs(t, env, "migrate", "up"); res.err != nil {
+		t.Fatalf("migrate up: %v\nstderr: %s", res.err, res.stderr)
+	}
+	if res := runArgs(t, env, "migrate", "up"); res.err != nil {
+		t.Fatalf("migrate up (idempotent): %v\nstderr: %s", res.err, res.stderr)
+	}
+}

--- a/cmd/pgrelay/integration_helpers_test.go
+++ b/cmd/pgrelay/integration_helpers_test.go
@@ -88,9 +88,14 @@ const runArgsTimeout = 30 * time.Second
 // its own helper that wires SIGTERM and timeouts.
 func runArgs(t testing.TB, envOverrides []string, args ...string) cmdResult {
 	t.Helper()
+	// Resolve the binary outside the timeout — the first caller pays
+	// the `go build -race` cost (~30s cold), and that's compile time,
+	// not subcommand runtime.
+	bin := buildBinary(t)
+
 	ctx, cancel := context.WithTimeout(t.Context(), runArgsTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, buildBinary(t), args...)
+	cmd := exec.CommandContext(ctx, bin, args...)
 	cmd.Env = append(envBaseline(), envOverrides...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/cmd/pgrelay/integration_helpers_test.go
+++ b/cmd/pgrelay/integration_helpers_test.go
@@ -1,0 +1,113 @@
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// One binary for the whole package — go build of the same source
+// produces an identical artifact, and a single compile keeps the
+// suite under ~60s on a cold runner. The dir lives through TestMain
+// so subsequent tests don't get a stale path after the first test's
+// t.TempDir cleanup.
+var (
+	binOnce sync.Once
+	binDir  string
+	binPath string
+	binErr  error
+)
+
+// TestMain owns the build directory's lifetime. Without this, the
+// `t.TempDir()` from the first caller of buildBinary would be deleted
+// at the end of that test and subsequent tests would exec a missing
+// path.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "pgrelay-bin-*")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "TestMain: create build dir:", err)
+		os.Exit(1)
+	}
+	binDir = dir
+	code := m.Run()
+	_ = os.RemoveAll(dir)
+	os.Exit(code)
+}
+
+func buildBinary(t testing.TB) string {
+	t.Helper()
+	binOnce.Do(func() {
+		binPath = filepath.Join(binDir, "pgrelay")
+		out, err := exec.Command("go", "build", "-o", binPath, "./").CombinedOutput()
+		if err != nil {
+			binErr = fmt.Errorf("%s: %w", string(out), err)
+		}
+	})
+	if binErr != nil {
+		t.Fatalf("build pgrelay binary: %v", binErr)
+	}
+	return binPath
+}
+
+// envBaseline returns a minimal env (PATH, HOME, TMPDIR) with every
+// PGRELAY_* stripped so a developer's local .env doesn't bleed into
+// the subprocess and mask assertion failures. Shared by every test
+// that invokes the binary.
+func envBaseline() []string {
+	keep := make([]string, 0, 3)
+	for _, k := range []string{"PATH", "TMPDIR", "HOME"} {
+		if v := os.Getenv(k); v != "" {
+			keep = append(keep, k+"="+v)
+		}
+	}
+	return keep
+}
+
+type cmdResult struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+// runArgsTimeout caps a one-shot subcommand. A hung migrate (e.g. an
+// unreachable DSN that blocks on TCP connect) is bounded here rather
+// than waiting for `go test -timeout`.
+const runArgsTimeout = 30 * time.Second
+
+// runArgs runs the built binary once and captures stdout + stderr.
+// One-shot — for `version` and `migrate`. The `run` subcommand has
+// its own helper that wires SIGTERM and timeouts.
+func runArgs(t testing.TB, envOverrides []string, args ...string) cmdResult {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), runArgsTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, buildBinary(t), args...)
+	cmd.Env = append(envBaseline(), envOverrides...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return cmdResult{stdout: stdout.String(), stderr: stderr.String(), err: err}
+}
+
+// drainBuffer pumps r into buf in a goroutine. EOF fires when *exec.Cmd
+// closes the pipe after Wait, so the returned done channel signals
+// "subprocess output fully captured". Callers must read done before
+// returning to keep the goroutine bounded by the test's lifetime.
+func drainBuffer(buf *bytes.Buffer, r io.Reader) chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(buf, r)
+		close(done)
+	}()
+	return done
+}

--- a/cmd/pgrelay/main.go
+++ b/cmd/pgrelay/main.go
@@ -39,6 +39,7 @@ func dispatch() error {
 		Commands: []*cli.Command{
 			versionCommand(),
 			migrateCommand(),
+			runCommand(),
 		},
 	}
 	return cmd.Run(ctx, os.Args)

--- a/cmd/pgrelay/main.go
+++ b/cmd/pgrelay/main.go
@@ -2,8 +2,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
-	"runtime/debug"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/urfave/cli/v3"
 )
 
 // Version and Commit are overridden at build time via -ldflags.
@@ -14,39 +19,26 @@ var (
 )
 
 func main() {
-	fmt.Println(versionString())
+	if err := dispatch(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }
 
-func versionString() string {
-	commit := Commit
-	suffix := ""
-	if commit == "" {
-		commit, suffix = vcsRevision()
-	}
-	if commit == "" {
-		return fmt.Sprintf("pgrelay %s (commit unknown — built without --build-arg COMMIT)", Version)
-	}
-	return fmt.Sprintf("pgrelay %s (commit %s%s)", Version, commit, suffix)
-}
+// dispatch returns instead of calling os.Exit so deferred cleanup (signal
+// notify, future OTel flush) actually runs on error paths.
+func dispatch() error {
+	// SIGINT/SIGTERM cancellation flows into long-running subcommands
+	// (run, migrate) via the cli ctx; short ones (version) ignore it.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
-func vcsRevision() (revision, suffix string) {
-	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "", ""
+	cmd := &cli.Command{
+		Name:  "pgrelay",
+		Usage: "Postgres-native transactional outbox dispatcher",
+		Commands: []*cli.Command{
+			versionCommand(),
+		},
 	}
-	var modified bool
-	for _, s := range bi.Settings {
-		switch s.Key {
-		case "vcs.revision":
-			if s.Value != "" {
-				revision = s.Value[:min(len(s.Value), 7)]
-			}
-		case "vcs.modified":
-			modified = s.Value == "true"
-		}
-	}
-	if modified {
-		suffix = "+dirty"
-	}
-	return revision, suffix
+	return cmd.Run(ctx, os.Args)
 }

--- a/cmd/pgrelay/main.go
+++ b/cmd/pgrelay/main.go
@@ -38,6 +38,7 @@ func dispatch() error {
 		Usage: "Postgres-native transactional outbox dispatcher",
 		Commands: []*cli.Command{
 			versionCommand(),
+			migrateCommand(),
 		},
 	}
 	return cmd.Run(ctx, os.Args)

--- a/cmd/pgrelay/migrate.go
+++ b/cmd/pgrelay/migrate.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres" // pgx-compatible db driver
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"github.com/urfave/cli/v3"
+
+	"github.com/ronango/pgrelay/migrations"
+)
+
+// migrateCommand groups up/down/status against the embedded migrations.
+// DB URL precedence: --database-url flag overrides PGRELAY_DATABASE_URL.
+func migrateCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "migrate",
+		Usage: "Apply, roll back, or inspect database migrations",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "database-url",
+				Usage:   "Postgres connection string (overrides PGRELAY_DATABASE_URL)",
+				Sources: cli.EnvVars("PGRELAY_DATABASE_URL"),
+			},
+		},
+		Commands: []*cli.Command{
+			{
+				Name:  "up",
+				Usage: "Apply pending migrations",
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "steps",
+						Usage: "Apply only N migrations (0 means all)",
+					},
+				},
+				Action: migrateUpAction,
+			},
+			{
+				Name:  "down",
+				Usage: "Roll back migrations (requires --yes)",
+				Flags: []cli.Flag{
+					&cli.IntFlag{
+						Name:  "steps",
+						Value: 1,
+						Usage: "Number of migrations to roll back",
+					},
+					&cli.BoolFlag{
+						Name:  "yes",
+						Usage: "Confirm destructive rollback",
+					},
+				},
+				Action: migrateDownAction,
+			},
+			{
+				Name:   "status",
+				Usage:  "Print the applied migration version and dirty flag",
+				Action: migrateStatusAction,
+			},
+		},
+	}
+}
+
+func newMigrator(dsn string) (*migrate.Migrate, error) {
+	if dsn == "" {
+		return nil, errors.New("PGRELAY_DATABASE_URL or --database-url is required")
+	}
+	src, err := iofs.New(migrations.FS, ".")
+	if err != nil {
+		return nil, fmt.Errorf("migration source: %w", err)
+	}
+	m, err := migrate.NewWithSourceInstance("iofs", src, dsn)
+	if err != nil {
+		return nil, fmt.Errorf("migrate instance: %w", err)
+	}
+	return m, nil
+}
+
+// closeMigrator surfaces source/db close errors so a failed close on a
+// successful command still exits non-zero — leaking a DB connection on
+// a one-shot migrate run shouldn't be silent.
+func closeMigrator(m *migrate.Migrate) error {
+	srcErr, dbErr := m.Close()
+	if srcErr == nil && dbErr == nil {
+		return nil
+	}
+	return fmt.Errorf("close migrate: %w", errors.Join(srcErr, dbErr))
+}
+
+func migrateUpAction(_ context.Context, cmd *cli.Command) error {
+	m, err := newMigrator(cmd.String("database-url"))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = closeMigrator(m) }()
+
+	steps := cmd.Int("steps")
+	switch {
+	case steps > 0:
+		err = m.Steps(int(steps))
+	default:
+		err = m.Up()
+	}
+	if err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return fmt.Errorf("migrate up: %w", err)
+	}
+	fmt.Println("migrate up: ok")
+	return nil
+}
+
+func migrateDownAction(_ context.Context, cmd *cli.Command) error {
+	if !cmd.Bool("yes") {
+		return errors.New("migrate down requires --yes (destructive)")
+	}
+	steps := cmd.Int("steps")
+	if steps < 1 {
+		return fmt.Errorf("--steps must be >= 1, got %d", steps)
+	}
+
+	m, err := newMigrator(cmd.String("database-url"))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = closeMigrator(m) }()
+
+	if err := m.Steps(-int(steps)); err != nil && !errors.Is(err, migrate.ErrNoChange) {
+		return fmt.Errorf("migrate down: %w", err)
+	}
+	fmt.Printf("migrate down: rolled back %d migration(s)\n", steps)
+	return nil
+}
+
+func migrateStatusAction(_ context.Context, cmd *cli.Command) error {
+	m, err := newMigrator(cmd.String("database-url"))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = closeMigrator(m) }()
+
+	version, dirty, err := m.Version()
+	if errors.Is(err, migrate.ErrNilVersion) {
+		fmt.Println("migrate status: no migrations applied")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("migrate status: %w", err)
+	}
+	suffix := ""
+	if dirty {
+		suffix = " (DIRTY — manual repair required)"
+	}
+	fmt.Printf("migrate status: version=%d%s\n", version, suffix)
+	return nil
+}

--- a/cmd/pgrelay/run.go
+++ b/cmd/pgrelay/run.go
@@ -25,6 +25,11 @@ import (
 // by SIGINT/SIGTERM at that point.
 const otelFlushTimeout = 5 * time.Second
 
+// ErrShutdownTimeout is returned when subsystems don't drain within
+// cfg.ShutdownTimeout. Surfaced as a non-zero exit so k8s/systemd see
+// a non-graceful shutdown distinct from a clean stop.
+var ErrShutdownTimeout = errors.New("shutdown timeout exceeded")
+
 func runCommand() *cli.Command {
 	return &cli.Command{
 		Name:   "run",
@@ -92,13 +97,38 @@ func runAction(ctx context.Context, _ *cli.Command) error {
 	g.Go(func() error { return healthSrv.Run(gctx) })
 	g.Go(func() error { return dispatcher.Run(gctx) })
 
-	// context.Canceled here means SIGINT/SIGTERM — that's the
-	// success exit, not an error.
-	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+	err = waitWithShutdownBudget(ctx, g, cfg.ShutdownTimeout, log)
+	// context.Canceled means SIGINT/SIGTERM — that's the success exit.
+	if err != nil && !errors.Is(err, context.Canceled) {
 		return err
 	}
 	log.InfoContext(ctx, "pgrelay stopped")
 	return nil
+}
+
+// waitWithShutdownBudget waits for g to finish. Once the parent ctx is
+// canceled (SIGINT/SIGTERM), it caps the additional wait by timeout —
+// a stuck subsystem cannot pin the process open past this budget. The
+// k8s operator pairs this with terminationGracePeriodSeconds.
+func waitWithShutdownBudget(ctx context.Context, g *errgroup.Group, timeout time.Duration, log *slog.Logger) error {
+	errCh := make(chan error, 1)
+	go func() { errCh <- g.Wait() }()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+	}
+
+	t := time.NewTimer(timeout)
+	defer t.Stop()
+	select {
+	case err := <-errCh:
+		return err
+	case <-t.C:
+		log.WarnContext(ctx, "shutdown timeout exceeded, subsystems may not have drained", "timeout", timeout)
+		return ErrShutdownTimeout
+	}
 }
 
 func newLogger(level string) *slog.Logger {

--- a/cmd/pgrelay/run.go
+++ b/cmd/pgrelay/run.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/urfave/cli/v3"
 	"golang.org/x/sync/errgroup"
@@ -12,10 +14,16 @@ import (
 	"github.com/ronango/pgrelay/internal/config"
 	"github.com/ronango/pgrelay/internal/health"
 	"github.com/ronango/pgrelay/internal/metrics"
+	"github.com/ronango/pgrelay/internal/otel"
 	"github.com/ronango/pgrelay/internal/outbox"
 	"github.com/ronango/pgrelay/internal/outbox/sinks"
 	"github.com/ronango/pgrelay/internal/pgconn"
 )
+
+// otelFlushTimeout caps the BatchSpanProcessor drain on shutdown. The
+// flush runs on a fresh context because the parent is already canceled
+// by SIGINT/SIGTERM at that point.
+const otelFlushTimeout = 5 * time.Second
 
 func runCommand() *cli.Command {
 	return &cli.Command{
@@ -30,8 +38,27 @@ func runAction(ctx context.Context, _ *cli.Command) error {
 	if err != nil {
 		return err
 	}
-
 	log := newLogger(cfg.LogLevel)
+
+	flushOTel, err := otel.Setup(ctx, otel.Config{
+		ServiceName:      "pgrelay",
+		ServiceVersion:   Version,
+		OTLPEndpoint:     cfg.OTLPEndpoint,
+		OTLPHeaders:      cfg.OTLPHeaders,
+		TracesSampler:    cfg.TracesSampler,
+		TracesSamplerArg: cfg.TracesSamplerArg,
+	})
+	if err != nil {
+		return fmt.Errorf("otel setup: %w", err)
+	}
+	defer func() {
+		flushCtx, cancel := context.WithTimeout(context.Background(), otelFlushTimeout)
+		defer cancel()
+		if flushErr := flushOTel(flushCtx); flushErr != nil {
+			log.WarnContext(ctx, "otel flush failed", "err", flushErr)
+		}
+	}()
+
 	reg := metrics.NewRegistry()
 
 	pool, err := pgconn.New(ctx, pgconn.Config{

--- a/cmd/pgrelay/run.go
+++ b/cmd/pgrelay/run.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+
+	"github.com/urfave/cli/v3"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/ronango/pgrelay/internal/config"
+	"github.com/ronango/pgrelay/internal/health"
+	"github.com/ronango/pgrelay/internal/metrics"
+	"github.com/ronango/pgrelay/internal/outbox"
+	"github.com/ronango/pgrelay/internal/outbox/sinks"
+	"github.com/ronango/pgrelay/internal/pgconn"
+)
+
+func runCommand() *cli.Command {
+	return &cli.Command{
+		Name:   "run",
+		Usage:  "Start the dispatcher loop (blocks until SIGINT/SIGTERM)",
+		Action: runAction,
+	}
+}
+
+func runAction(ctx context.Context, _ *cli.Command) error {
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	log := newLogger(cfg.LogLevel)
+	reg := metrics.NewRegistry()
+
+	pool, err := pgconn.New(ctx, pgconn.Config{
+		DSN:               cfg.DatabaseURL,
+		MinConns:          cfg.DBMinConns,
+		MaxConns:          cfg.DBMaxConns,
+		MaxConnLifetime:   cfg.DBMaxConnLifetime,
+		MaxConnIdleTime:   cfg.DBMaxConnIdleTime,
+		HealthCheckPeriod: cfg.DBHealthCheckPeriod,
+	}, reg)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+
+	outbox.RegisterStateCollector(reg, pool, log)
+	om := outbox.NewMetrics(reg)
+
+	dispatcher := outbox.New(pool, sinks.NewHTTPSink(), outbox.NewPolicy(cfg), om, cfg, log)
+	healthSrv := health.New(cfg.OpsAddr, reg, health.ProbeFunc(pool.Ping))
+
+	log.InfoContext(ctx, "pgrelay starting",
+		"version", Version,
+		"commit", Commit,
+		"ops_addr", cfg.OpsAddr,
+		"db_max_conns", cfg.DBMaxConns,
+	)
+
+	// errgroup so the first subsystem failure cancels the others.
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error { return healthSrv.Run(gctx) })
+	g.Go(func() error { return dispatcher.Run(gctx) })
+
+	// context.Canceled here means SIGINT/SIGTERM — that's the
+	// success exit, not an error.
+	if err := g.Wait(); err != nil && !errors.Is(err, context.Canceled) {
+		return err
+	}
+	log.InfoContext(ctx, "pgrelay stopped")
+	return nil
+}
+
+func newLogger(level string) *slog.Logger {
+	var lvl slog.Level
+	// config.Validate normalizes LogLevel to one of {debug,info,warn,error},
+	// so UnmarshalText cannot fail here in practice.
+	_ = lvl.UnmarshalText([]byte(level))
+	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: lvl}))
+}

--- a/cmd/pgrelay/run_integration_test.go
+++ b/cmd/pgrelay/run_integration_test.go
@@ -1,0 +1,142 @@
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/ronango/pgrelay/internal/testdb"
+)
+
+// freePort grabs an ephemeral port the kernel just released. There's
+// an inherent race between Close and the dispatcher binding it, but
+// the loopback window is microsecond-scale and reliable in practice.
+// The alternative — parsing the dispatcher's startup log — is fragile.
+func freePort(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for free port: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close listener: %v", err)
+	}
+	return addr
+}
+
+func seedPending(t *testing.T, pool *pgxpool.Pool, destination string) {
+	t.Helper()
+	const sql = `
+		INSERT INTO pgrelay_outbox (aggregate_type, aggregate_id, event_type, payload, sink, destination)
+		VALUES ('order', 'agg-1', 'created', '{"k":"v"}'::jsonb, 'http', $1)
+	`
+	if _, err := pool.Exec(t.Context(), sql, destination); err != nil {
+		t.Fatalf("seed pending row: %v", err)
+	}
+}
+
+func TestRun_HappyPathDeliversThenShutsDown(t *testing.T) {
+	pool := testdb.New(t)
+	dsn := pool.Config().ConnString()
+
+	received := make(chan struct{}, 1)
+	sinkSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case received <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(sinkSrv.Close)
+
+	seedPending(t, pool, sinkSrv.URL)
+
+	bin := buildBinary(t)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	// CommandContext sends SIGKILL on ctx done; here that's a safety
+	// net only — the test exercises SIGTERM via cmd.Process.Signal.
+	cmd := exec.CommandContext(ctx, bin, "run")
+	cmd.Env = append(envBaseline(),
+		"PGRELAY_DATABASE_URL="+dsn,
+		"PGRELAY_OPS_ADDR="+freePort(t),
+		"PGRELAY_POLL_INTERVAL=50ms",
+		"PGRELAY_LEASE_DURATION=2s",
+		"PGRELAY_SHUTDOWN_TIMEOUT=3s",
+	)
+
+	var stdout, stderr bytes.Buffer
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("StdoutPipe: %v", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		t.Fatalf("StderrPipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start pgrelay: %v", err)
+	}
+	stdoutDone := drainBuffer(&stdout, stdoutPipe)
+	stderrDone := drainBuffer(&stderr, stderrPipe)
+
+	select {
+	case <-received:
+	case <-time.After(10 * time.Second):
+		_ = cmd.Process.Kill()
+		<-stdoutDone
+		<-stderrDone
+		t.Fatalf("sink never received a request; stdout=%s\nstderr=%s", stdout.String(), stderr.String())
+	}
+
+	if err := cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("send SIGTERM: %v", err)
+	}
+
+	if err := waitWithTimeout(cmd, 10*time.Second); err != nil {
+		t.Fatalf("pgrelay run exit: %v\nstdout=%s\nstderr=%s", err, stdout.String(), stderr.String())
+	}
+	<-stdoutDone
+	<-stderrDone
+}
+
+func TestRun_NonZeroExitOnMissingConfig(t *testing.T) {
+	bin := buildBinary(t)
+	cmd := exec.Command(bin, "run")
+	cmd.Env = envBaseline() // strip inherited PGRELAY_*
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit when PGRELAY_DATABASE_URL is missing; output=%s", out)
+	}
+	if !strings.Contains(string(out), "PGRELAY_DATABASE_URL") {
+		t.Errorf("error output = %q, want mention of PGRELAY_DATABASE_URL", out)
+	}
+}
+
+var errWaitTimeout = errors.New("pgrelay did not exit within timeout (killed)")
+
+func waitWithTimeout(cmd *exec.Cmd, timeout time.Duration) error {
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(timeout):
+		_ = cmd.Process.Kill()
+		return errWaitTimeout
+	}
+}

--- a/cmd/pgrelay/version.go
+++ b/cmd/pgrelay/version.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"runtime/debug"
+
+	"github.com/urfave/cli/v3"
+)
+
+func versionCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "version",
+		Usage: "Print version, commit, and Go runtime",
+		Action: func(_ context.Context, _ *cli.Command) error {
+			fmt.Println(versionString())
+			return nil
+		},
+	}
+}
+
+func versionString() string {
+	commit := Commit
+	suffix := ""
+	if commit == "" {
+		commit, suffix = vcsRevision()
+	}
+	if commit == "" {
+		return fmt.Sprintf("pgrelay %s (commit unknown, %s)", Version, runtime.Version())
+	}
+	return fmt.Sprintf("pgrelay %s (commit %s%s, %s)", Version, commit, suffix, runtime.Version())
+}
+
+func vcsRevision() (revision, suffix string) {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "", ""
+	}
+	var modified bool
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if s.Value != "" {
+				revision = s.Value[:min(len(s.Value), 7)]
+			}
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+	if modified {
+		suffix = "+dirty"
+	}
+	return revision, suffix
+}

--- a/cmd/pgrelay/version_test.go
+++ b/cmd/pgrelay/version_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func withVersion(t *testing.T, v, c string) {
+	t.Helper()
+	prevV, prevC := Version, Commit
+	t.Cleanup(func() { Version = prevV; Commit = prevC })
+	Version, Commit = v, c
+}
+
+func TestVersionString_WithExplicitCommit(t *testing.T) {
+	withVersion(t, "1.2.3", "abcdef1")
+	got := versionString()
+	for _, want := range []string{"pgrelay", "1.2.3", "abcdef1", runtime.Version()} {
+		if !strings.Contains(got, want) {
+			t.Errorf("versionString = %q, missing %q", got, want)
+		}
+	}
+}
+
+func TestVersionString_EmptyCommitFallsBackToVCSOrUnknown(t *testing.T) {
+	withVersion(t, "dev", "")
+	got := versionString()
+	// Either go test injected vcs info (run from a git checkout) or
+	// it didn't (run from a tarball) — both branches must produce a
+	// non-empty string that mentions pgrelay + the Go runtime.
+	if !strings.Contains(got, "pgrelay") || !strings.Contains(got, runtime.Version()) {
+		t.Errorf("versionString = %q, want pgrelay + go runtime tag", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
+	github.com/urfave/cli/v3 v3.8.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/sync v0.20.0
 )
 
 require (
@@ -79,7 +80,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -151,6 +151,8 @@ github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYI
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=
 github.com/tklauser/numcpus v0.11.0/go.mod h1:z+LwcLq54uWZTX0u/bGobaV34u6V7KNlTZejzM6/3MQ=
+github.com/urfave/cli/v3 v3.8.0 h1:XqKPrm0q4P0q5JpoclYoCAv0/MIvH/jZ2umzuf8pNTI=
+github.com/urfave/cli/v3 v3.8.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,13 @@ type Config struct {
 	RetryBase     time.Duration `env:"PGRELAY_RETRY_BASE"     envDefault:"1s"`
 	RetryMax      time.Duration `env:"PGRELAY_RETRY_MAX"      envDefault:"5m"`
 	RetryJitter   float64       `env:"PGRELAY_RETRY_JITTER"   envDefault:"0.2"`
+
+	// Process-level shutdown budget for the run subcommand. Caps how
+	// long the binary waits for dispatcher + health subsystems to
+	// drain after SIGINT/SIGTERM. Recommend k8s
+	// terminationGracePeriodSeconds set above this plus the OTel
+	// flush budget (a few seconds).
+	ShutdownTimeout time.Duration `env:"PGRELAY_SHUTDOWN_TIMEOUT" envDefault:"30s"`
 }
 
 // maxBatchSize caps PGRELAY_BATCH_SIZE so a misconfigured env var can't
@@ -183,6 +190,9 @@ func (c *Config) Validate() error {
 	}
 	if c.RetryJitter < 0 || c.RetryJitter > 1 {
 		return fmt.Errorf("PGRELAY_RETRY_JITTER: must be in [0, 1], got %v", c.RetryJitter)
+	}
+	if c.ShutdownTimeout < time.Second {
+		return fmt.Errorf("PGRELAY_SHUTDOWN_TIMEOUT: must be >= 1s, got %s", c.ShutdownTimeout)
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -280,6 +280,7 @@ func TestLoad_DispatcherDefaults(t *testing.T) {
 		{"RetryBase", cfg.RetryBase, time.Second},
 		{"RetryMax", cfg.RetryMax, 5 * time.Minute},
 		{"RetryJitter", cfg.RetryJitter, 0.2},
+		{"ShutdownTimeout", cfg.ShutdownTimeout, 30 * time.Second},
 	}
 	for _, c := range checks {
 		if c.got != c.want {
@@ -297,6 +298,7 @@ func TestLoad_DispatcherOverrides(t *testing.T) {
 	t.Setenv("PGRELAY_RETRY_BASE", "500ms")
 	t.Setenv("PGRELAY_RETRY_MAX", "10m")
 	t.Setenv("PGRELAY_RETRY_JITTER", "0.5")
+	t.Setenv("PGRELAY_SHUTDOWN_TIMEOUT", "45s")
 
 	cfg, err := Load()
 	if err != nil {
@@ -315,6 +317,7 @@ func TestLoad_DispatcherOverrides(t *testing.T) {
 		{"RetryBase", cfg.RetryBase, 500 * time.Millisecond},
 		{"RetryMax", cfg.RetryMax, 10 * time.Minute},
 		{"RetryJitter", cfg.RetryJitter, 0.5},
+		{"ShutdownTimeout", cfg.ShutdownTimeout, 45 * time.Second},
 	}
 	for _, c := range checks {
 		if c.got != c.want {
@@ -358,6 +361,7 @@ func TestLoad_DispatcherInvalid(t *testing.T) {
 			"PGRELAY_RETRY_MAX":  "1s",
 		}, "PGRELAY_RETRY_MAX"},
 		{"batch_size_above_ceiling", map[string]string{"PGRELAY_BATCH_SIZE": "100000"}, "PGRELAY_BATCH_SIZE"},
+		{"shutdown_timeout_below_floor", map[string]string{"PGRELAY_SHUTDOWN_TIMEOUT": "500ms"}, "PGRELAY_SHUTDOWN_TIMEOUT"},
 		{"lease_duration_at_poll_interval", map[string]string{
 			"PGRELAY_LEASE_DURATION": "100ms",
 			"PGRELAY_POLL_INTERVAL":  "100ms",


### PR DESCRIPTION
Closes #7.

Implements the issue's acceptance criteria — `pgrelay run`, `pgrelay migrate up|down|status`, and `pgrelay version` on urfave/cli/v3, with graceful shutdown bounded by `PGRELAY_SHUTDOWN_TIMEOUT`. Notes cover only divergence and additions beyond issue scope.

## Diverged from issue scope

- **Lease sweeper is a `select` arm of `Run`, not a separate goroutine.** Issue described "separate goroutine sweeps `status='in_flight' AND leased_until < now()` back to `pending`". Shipped as the second ticker arm inside the dispatcher's main loop (already merged in #18). The cmd binary inherits this — no second goroutine to wire, no separate cancellation handshake.
- **Migration down step semantics.** Issue listed `migrate up|down|status [--steps N]` as one flag shared across subcommands. Shipped:
  - `up` takes `--steps N` (apply N pending migrations, default = all).
  - `down` takes `--steps N` defaulting to **1**, and requires `--yes`. The fat-finger guard is more useful when down's default is "one step" rather than "all", since the destructive-rollback risk concentrates there.
  - `status` takes no flags — prints version + dirty marker.
- **Distinct sentinel for shutdown-timeout exit.** Returned `ErrShutdownTimeout` on a timeout-exceeded shutdown, surfaced as a non-zero exit code via urfave/cli's error path. Issue didn't mandate exit semantics; defaulting to "exit 0 after a WARN log" hides a real signal from systemd / k8s.

## Added beyond issue scope

- **`PGRELAY_SHUTDOWN_TIMEOUT` config field** (default `30s`, minimum `1s`). Validated at boot. Doc on the field references the operator's expected k8s `terminationGracePeriodSeconds` tuning (above this plus the OTel flush budget).
- **OTel flush bounded separately** (5s, package-level `otelFlushTimeout`). Runs on a fresh `context.Background()` because the parent ctx is already canceled by SIGINT/SIGTERM at that point.
- **Subprocess-based integration tests.** Issue's acceptance criteria called for `docker run pgrelay run` against testcontainers PG. Shipped equivalent without the docker-in-docker layer: `go build` once via `sync.Once` + `TestMain`-owned `os.MkdirTemp`, then `os/exec` against a live testcontainers PG. Tests cover happy path (seed pending row → wait for httptest sink hit → SIGTERM → assert clean exit), non-zero exit on missing config, full migrate lifecycle (status → down refused without --yes → down --yes → up → up idempotent), and `version` end-to-end through the ldflags fallback path.
- **`envBaseline()` helper** strips inherited `PGRELAY_*` from subprocess environments so a developer's local `.env` can't mask assertion failures during the integration suite.
- **`waitWithShutdownBudget` extracted as a package function** so the shutdown choreography (errgroup wait → ctx cancel → bounded wait → SIGKILL safety net) is reviewable in one place instead of inlined in `runAction`.

## Verification

- `make build / test / lint / vuln` — green locally with Go 1.25.10 (host can't run integration tests due to the known testcontainers + Fedora 43 netfilter issue; CI exercises them on a Linux runner).
- CI on this PR: `floor`, `golangci-lint`, `govulncheck`, `unit (1.25)`, `integration (14/15/16/17)`.