### PR TITLE
fix(outbox): input validation hardening

### DIFF
--- a/internal/outbox/dispatcher.go
+++ b/internal/outbox/dispatcher.go
@@ -3,6 +3,7 @@ package outbox
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -27,6 +28,11 @@ type Dispatcher struct {
 // finalizeTimeout caps the detached terminal-write so a canceled
 // dispatch still persists its outcome instead of leaking to the sweeper.
 const finalizeTimeout = 5 * time.Second
+
+// maxPayloadBytes guards against an INSERT'ed oversized JSONB blob
+// OOM-killing the dispatcher on every retry. App-layer only; DB-level
+// CHECK is a future migration.
+const maxPayloadBytes = 1 << 20
 
 // New wires a Dispatcher.
 func New(pool *pgxpool.Pool, sink sinks.Sink, policy *Policy, metrics *Metrics, cfg config.Config, log *slog.Logger) *Dispatcher {
@@ -87,6 +93,18 @@ func (d *Dispatcher) poll(ctx context.Context) {
 }
 
 func (d *Dispatcher) dispatch(ctx context.Context, row Row) {
+	if len(row.Payload) > maxPayloadBytes {
+		writeCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), finalizeTimeout)
+		defer cancel()
+		errStr := fmt.Sprintf("payload %d bytes exceeds %d cap", len(row.Payload), maxPayloadBytes)
+		if err := MarkDead(writeCtx, d.pool, row.ID, errStr); err != nil {
+			d.log.ErrorContext(writeCtx, "mark dead failed", "id", row.ID, "err", err, "last_error", errStr)
+			return
+		}
+		d.metrics.Attempts.WithLabelValues(ResultDead).Inc()
+		return
+	}
+
 	msg := sinks.Message{
 		ID:            row.ID,
 		AggregateType: row.AggregateType,

--- a/internal/outbox/dispatcher_integration_test.go
+++ b/internal/outbox/dispatcher_integration_test.go
@@ -5,6 +5,7 @@ package outbox_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -100,6 +101,33 @@ func TestDispatcher_HappyPath(t *testing.T) {
 	}
 	if got := f.attemptsCount(outbox.ResultSent); got < 1 {
 		t.Errorf("attempts_total{sent} = %v, want >= 1", got)
+	}
+}
+
+func TestDispatcher_OversizedPayloadMarkedDeadWithoutSending(t *testing.T) {
+	pool := testdb.New(t)
+	f := startDispatcher(t, pool, fastConfig())
+
+	// 1 MiB + 1 byte — over the dispatcher cap.
+	oversized := make([]byte, (1<<20)+1)
+	for i := range oversized {
+		oversized[i] = 'x'
+	}
+	// Wrap as JSON string so the JSONB column accepts it.
+	payload := append([]byte{'"'}, oversized...)
+	payload = append(payload, '"')
+
+	id := insertRow(t, pool, insertOpts{Payload: payload})
+
+	r := waitForStatus(t, pool, id, "dead", 2*time.Second)
+	if !strings.Contains(r.LastError, "exceeds") {
+		t.Errorf("LastError = %q, want mention of cap exceeded", r.LastError)
+	}
+	if f.Sink.SentCount() != 0 {
+		t.Errorf("sink saw %d messages, want 0 (oversized never sent)", f.Sink.SentCount())
+	}
+	if got := f.attemptsCount(outbox.ResultDead); got < 1 {
+		t.Errorf("attempts_total{dead} = %v, want >= 1", got)
 	}
 }
 

--- a/internal/outbox/sinks/http.go
+++ b/internal/outbox/sinks/http.go
@@ -90,6 +90,20 @@ func (s *HTTPSink) Send(ctx context.Context, msg Message) error {
 	if msg.Destination == "" {
 		return errors.New("destination required")
 	}
+	if msg.Traceparent != "" && !validHeaderValue(msg.Traceparent) {
+		return errors.New("traceparent contains control character")
+	}
+	if msg.Tracestate != "" && !validHeaderValue(msg.Tracestate) {
+		return errors.New("tracestate contains control character")
+	}
+	for k, v := range msg.Headers {
+		if !validHeaderName(k) {
+			return fmt.Errorf("header name %q invalid (RFC 7230 tchar)", k)
+		}
+		if !validHeaderValue(v) {
+			return fmt.Errorf("header %q value contains control character", k)
+		}
+	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, msg.Destination, bytes.NewReader(msg.Payload))
 	if err != nil {
@@ -165,6 +179,46 @@ func isRetryableStatus(status int) bool {
 		return true
 	}
 	return status >= 500 && status < 600
+}
+
+// validHeaderValue mirrors net/textproto's check: rejects any control
+// byte below 0x20 (except tab) and DEL (0x7f). Without this bail-early
+// the row would be retried until MaxAttempts on transport-classified
+// errors. OWS around values is not stripped — Go's net/http passes them
+// through; producers must trim if downstream peers are strict.
+func validHeaderValue(v string) bool {
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		if c == '\t' {
+			continue
+		}
+		if c < 0x20 || c == 0x7f {
+			return false
+		}
+	}
+	return true
+}
+
+// validHeaderName rejects characters HTTP forbids in header names per
+// RFC 7230 §3.2.6 (control bytes, separators, and whitespace).
+func validHeaderName(name string) bool {
+	// Empty must be rejected explicitly — the loop alone would pass it.
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		// tchar set: alphanumerics + !#$%&'*+-.^_`|~
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case strings.IndexByte("!#$%&'*+-.^_`|~", c) >= 0:
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // parseRetryAfter returns the duration encoded in a Retry-After header.

--- a/internal/outbox/sinks/http_test.go
+++ b/internal/outbox/sinks/http_test.go
@@ -327,6 +327,80 @@ func TestHTTPSink_EmptyDestinationTerminal(t *testing.T) {
 	}
 }
 
+func TestHTTPSink_RejectsMalformedHeaderFields(t *testing.T) {
+	// Producer can write control bytes (CR/LF/NUL, DEL, other <0x20)
+	// into traceparent/tracestate/headers. Without validation the row
+	// is retried up to MaxAttempts; the sink rejects terminally instead.
+	cases := []struct {
+		name string
+		msg  sinks.Message
+		want string
+	}{
+		{
+			name: "traceparent_with_lf",
+			msg:  sinks.Message{ID: 1, Destination: "http://x.test", Payload: []byte("{}"), Traceparent: "tp\nX-Admin: 1"},
+			want: "traceparent",
+		},
+		{
+			name: "tracestate_with_cr",
+			msg:  sinks.Message{ID: 1, Destination: "http://x.test", Payload: []byte("{}"), Tracestate: "ts\rinjected"},
+			want: "tracestate",
+		},
+		{
+			name: "user_header_value_with_nul",
+			msg: sinks.Message{
+				ID: 1, Destination: "http://x.test", Payload: []byte("{}"),
+				Headers: map[string]string{"X-Custom": "value\x00null"},
+			},
+			want: "X-Custom",
+		},
+		{
+			name: "user_header_name_with_space",
+			msg: sinks.Message{
+				ID: 1, Destination: "http://x.test", Payload: []byte("{}"),
+				Headers: map[string]string{"X Bad": "ok"},
+			},
+			want: "X Bad",
+		},
+		{
+			name: "user_header_name_empty",
+			msg: sinks.Message{
+				ID: 1, Destination: "http://x.test", Payload: []byte("{}"),
+				Headers: map[string]string{"": "ok"},
+			},
+			want: "RFC 7230",
+		},
+		{
+			name: "traceparent_with_nul",
+			msg:  sinks.Message{ID: 1, Destination: "http://x.test", Payload: []byte("{}"), Traceparent: "tp\x00inj"},
+			want: "traceparent",
+		},
+		{
+			name: "header_value_with_del",
+			msg: sinks.Message{
+				ID: 1, Destination: "http://x.test", Payload: []byte("{}"),
+				Headers: map[string]string{"X-Custom": "before\x7fafter"},
+			},
+			want: "X-Custom",
+		},
+	}
+	sink := sinks.NewHTTPSink()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := sink.Send(t.Context(), tc.msg)
+			if err == nil {
+				t.Fatal("Send returned nil for malformed header")
+			}
+			if sinks.IsRetryable(err) {
+				t.Errorf("malformed header classified as retryable: %v", err)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q missing %q for diagnosability", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestHTTPSink_ErrorIncludesBodySnippet(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/internal/outbox/status.go
+++ b/internal/outbox/status.go
@@ -3,10 +3,43 @@ package outbox
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// maxLastErrorBytes ≈ HTTP error snippet (512) + wrapping headroom.
+const maxLastErrorBytes = 4096
+
+// sanitizeLastError strips control bytes (TTY-escape footgun) and
+// caps length. Double-truncate because strings.Map decodes invalid
+// UTF-8 as U+FFFD (3 bytes), inflating adversarial input past the cap.
+func sanitizeLastError(s string) string {
+	s = truncateAtRuneBoundary(s, maxLastErrorBytes)
+	out := strings.Map(func(r rune) rune {
+		if r == '\t' || r == '\n' {
+			return r
+		}
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
+	return truncateAtRuneBoundary(out, maxLastErrorBytes)
+}
+
+func truncateAtRuneBoundary(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	end := maxBytes
+	for end > 0 && !utf8.RuneStart(s[end]) {
+		end--
+	}
+	return s[:end]
+}
 
 // MarkSent transitions a claimed row to status='sent'. Caller invokes
 // after sink.Send returns nil.
@@ -36,7 +69,7 @@ func MarkRetry(ctx context.Context, pool *pgxpool.Pool, id int64, nextAttemptAt 
 		    last_error = $3,
 		    leased_until = NULL
 		WHERE id = $1
-	`, id, nextAttemptAt, lastError)
+	`, id, nextAttemptAt, sanitizeLastError(lastError))
 	if err != nil {
 		return fmt.Errorf("mark retry %d: %w", id, err)
 	}
@@ -53,7 +86,7 @@ func MarkDead(ctx context.Context, pool *pgxpool.Pool, id int64, lastError strin
 		    last_error = $2,
 		    leased_until = NULL
 		WHERE id = $1
-	`, id, lastError)
+	`, id, sanitizeLastError(lastError))
 	if err != nil {
 		return fmt.Errorf("mark dead %d: %w", id, err)
 	}

--- a/internal/outbox/status_test.go
+++ b/internal/outbox/status_test.go
@@ -1,0 +1,71 @@
+package outbox
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestSanitizeLastError_StripsControlBytes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain", "503 upstream timeout", "503 upstream timeout"},
+		{"keeps_tab", "code\t503", "code\t503"},
+		{"keeps_newline", "line1\nline2", "line1\nline2"},
+		{"strips_cr", "before\rafter", "beforeafter"},
+		{"strips_nul", "before\x00after", "beforeafter"},
+		{"strips_esc", "\x1b[31mred\x1b[0m", "[31mred[0m"},
+		{"strips_del", "before\x7fafter", "beforeafter"},
+		{"strips_low_control", "\x01\x02\x03text", "text"},
+		{"keeps_utf8", "ошибка 503", "ошибка 503"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeLastError(tc.in); got != tc.want {
+				t.Errorf("sanitizeLastError(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeLastError_TruncatesAtCap(t *testing.T) {
+	in := strings.Repeat("a", maxLastErrorBytes+500)
+	got := sanitizeLastError(in)
+	if len(got) != maxLastErrorBytes {
+		t.Errorf("len = %d, want %d", len(got), maxLastErrorBytes)
+	}
+}
+
+func TestSanitizeLastError_BoundedOnAdversarialUTF8(t *testing.T) {
+	// 0xE5 alone is a UTF-8 lead byte without continuation; strings.Map
+	// decodes each as U+FFFD (3 bytes encoded). Without the post-Map
+	// re-cap the cap would be busted 3x.
+	in := strings.Repeat("\xe5", maxLastErrorBytes+100)
+	got := sanitizeLastError(in)
+	if len(got) > maxLastErrorBytes {
+		t.Errorf("len = %d, want <= %d (adversarial UTF-8 inflated past cap)", len(got), maxLastErrorBytes)
+	}
+}
+
+func TestSanitizeLastError_AllContinuationBytesReturnsEmpty(t *testing.T) {
+	// Pathological input — every byte is a UTF-8 continuation byte
+	// (0x80). truncateAtRuneBoundary walks all the way to end=0.
+	in := strings.Repeat("\x80", maxLastErrorBytes+10)
+	if got := sanitizeLastError(in); got != "" {
+		t.Errorf("len = %d, want 0 (no rune starts to truncate at)", len(got))
+	}
+}
+
+func TestSanitizeLastError_DoesNotSplitMultibyteRune(t *testing.T) {
+	// 'ё' is 2 bytes (0xD1 0x91). Position it so the cap falls between
+	// its two bytes — the truncator must back up to a rune boundary.
+	prefix := strings.Repeat("a", maxLastErrorBytes-1)
+	in := prefix + "ё" + "tail"
+	got := sanitizeLastError(in)
+	if !utf8.ValidString(got) {
+		t.Errorf("output is not valid UTF-8: %q", got)
+	}
+}


### PR DESCRIPTION
Pre-release hardening before v0.1.0-alpha. Three commits address producer-controlled inputs that today bypass dispatcher safety nets.

## Changes

- **`fix(sinks): reject control characters in HTTP headers before send`** — `Traceparent`, `Tracestate`, and user-`Headers` are validated in `HTTPSink.Send` against the same control-byte set `net/textproto` enforces (`< 0x20` except `\t`, plus `0x7f`). Header names checked against RFC 7230 tchar. Without this, a producer-written `traceparent` with `\r\n` was wrapped as `RetryableError` and looped until `MaxAttempts` — now it terminates on first attempt.
- **`fix(outbox): sanitize last_error before write`** — `MarkRetry` and `MarkDead` route through `sanitizeLastError(s)`: strips control bytes (TTY-escape footgun), caps at 4 KiB, and respects UTF-8 rune boundaries with a post-`strings.Map` re-cap (Map decodes invalid bytes as U+FFFD, 3 bytes encoded, so adversarial input can inflate past the cap without the re-truncate).
- **`fix(outbox): reject oversized payloads before dispatch`** — `Dispatcher.dispatch` rejects rows with `len(Payload) > 1 MiB` by marking dead before allocating the `sinks.Message`. Breaks the OOM-redelivery loop where a single oversized row could crash the process every restart. App-layer only; DB-level `CHECK` constraint is queued for a v0.2 migration.

## Out of scope

- DB-level payload `CHECK` constraint (v0.2 migration).
- `Claim` pre-filter via `octet_length(payload)` to avoid the initial OOM read.
- Dedicated metric label distinguishing oversized rejections from sink-terminal failures (`Attempts{result="dead"}` currently conflates them).

## Verification

- `make build / test / lint / vuln` — green locally with Go 1.25.10.
- CI on this PR: `floor`, `golangci-lint`, `govulncheck`, `unit (1.25)`, `integration (14/15/16/17)` — integration covers the new oversized-payload test against real Postgres.