### PR TITLE
docs(sinks): note SSRF trust boundary on HTTPSink

### DIFF
--- a/internal/outbox/sinks/http.go
+++ b/internal/outbox/sinks/http.go
@@ -16,6 +16,11 @@ import (
 // retryable (408 / 425 / 429 / 5xx + network errors) and terminal
 // (everything else, including malformed destinations and 3xx); the
 // dispatcher (#6) owns the retry policy and surfaces metrics.
+//
+// Trust boundary: any caller with INSERT on pgrelay_outbox controls
+// row.destination, and pgrelay will POST to that URL from the
+// dispatcher's network — restrict INSERT to trusted producers or this
+// becomes an SSRF pivot inside the cluster.
 type HTTPSink struct {
 	client *http.Client
 }


### PR DESCRIPTION
Pre-release docs hardening. The HTTPSink struct godoc now spells out the trust assumption that today is implicit: any caller with INSERT on `pgrelay_outbox` controls `row.destination`, and pgrelay will issue an outbound POST to that URL from the dispatcher's network. Operators reading the source should see "this is an SSRF pivot if INSERT isn't restricted to trusted producers" before they wire pgrelay into a shared schema.

## Verification

- `make build / test / lint / vuln` — green locally with Go 1.25.10.
- Pure docs change; no code paths affected.