### PR TITLE
release: pre-v0.1.0-alpha polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0-alpha] - 2026-05-13
+
+Initial alpha release. Single-process Postgres-outbox dispatcher with HTTP sink, retry/dead-letter policy, and an OpenTelemetry-aware wire protocol. Integration-tested against PG 14 / 15 / 16 / 17.
+
+### Added
+
+- `pgrelay_outbox` table with partial indexes on `(next_attempt_at)` and `(leased_until)` for the dispatcher's hot paths.
+- `pgrelay` binary with three subcommands:
+  - `version` — build version, commit, Go runtime
+  - `migrate {up,down,status} [--steps N] [--yes]` — `golang-migrate` wrapper; `down` requires explicit `--yes` confirmation
+  - `run` — wires pool, dispatcher, and health server; blocks until SIGINT/SIGTERM with bounded graceful shutdown
+- HTTP sink: POST `application/json`, classify 408/425/429/5xx as retryable (with `Retry-After` honored as a floor), 3xx as terminal (no redirect-following), reserved-header allowlist for `Content-Type` / `Idempotency-Key` / `traceparent` / `tracestate`.
+- Lease-based claim via `FOR UPDATE SKIP LOCKED` + CTE wrapper for deterministic RETURNING order.
+- Exponential backoff with jitter; pluggable RNG for deterministic tests.
+- Lease sweeper reclaims orphaned `in_flight` rows whose `leased_until` has expired.
+- Input validation: rejects HTTP header control bytes (CR, LF, NUL, DEL, and other ASCII controls), sanitizes `last_error` (4 KiB cap, control-byte strip, UTF-8 safe with no mid-rune truncation), drops rows whose payload exceeds 1 MiB.
+- W3C trace context propagation through `traceparent` / `tracestate` headers.
+- OpenTelemetry SDK setup with OTLP/HTTP exporter and configurable sampler.
+- Prometheus surface: `pgrelay_outbox_attempts_total{result}`, `pgrelay_outbox_dispatch_duration_seconds{sink}`, `pgrelay_outbox_orphans_reclaimed_total`, `pgrelay_outbox_backlog_seconds`, `pgrelay_outbox_rows{status}`, plus `pgrelay_db_query_*` and `pgrelay_db_pool_*` from the pgx tracer.
+- Health endpoints (`/healthz`, `/readyz`) and Prometheus scrape (`/metrics`) on configurable `PGRELAY_OPS_ADDR`.
+- Graceful shutdown bounded by `PGRELAY_SHUTDOWN_TIMEOUT` (default 30s); non-zero exit on timeout via `ErrShutdownTimeout`.
+- Integration tests across PG 14 / 15 / 16 / 17 via `testcontainers-go`.
+- Distroless-nonroot Dockerfile suitable for multi-arch build.
+
+### Known Limitations
+
+- Dispatcher emits no OpenTelemetry spans of its own — only header-level propagation. Dispatcher spans land in v0.2.0.
+- Per-aggregate ordering is not guaranteed under concurrent producers because `BIGSERIAL` is monotonic per connection, not per commit. Global ordering by `next_attempt_at` is preserved.
+- Payload size guard is app-layer only; DB-level `CHECK` constraint deferred to a v0.2 migration.
+- `internal/outbox` couples to `internal/config` for dispatcher configuration. An embeddable Go API (`pkg/pgrelay`) and the corresponding decoupling are planned for v0.2.0.
+- Kafka sink, polyglot examples (Go + Python producers), and benchmarks are roadmap items — see [README](./README.md#roadmap).
+
+[0.1.0-alpha]: https://github.com/ronango/pgrelay/releases/tag/v0.1.0-alpha

--- a/README.md
+++ b/README.md
@@ -4,18 +4,42 @@
 
 ## Status
 
-🚧 **Under construction.** Working toward `v0.1.0-alpha` (HTTP sink + lease-based claim + integration tests on PG 14–17).
+`v0.1.0-alpha` — HTTP sink, lease-based claim with `FOR UPDATE SKIP LOCKED`, exponential backoff with jitter, lease sweeper for orphaned rows, Prometheus surface, W3C trace context propagation, graceful shutdown. Integration-tested against PG 14 / 15 / 16 / 17.
 
 ## What it does
 
-A small Go binary that polls a Postgres outbox table and dispatches rows to HTTP or Kafka, with **end-to-end W3C trace context propagation** — so a span started in your Python service stays connected to the span on your Go consumer, across the async hop.
+A small Go binary that polls a Postgres outbox table and dispatches rows to HTTP (Kafka in v0.2), with **end-to-end W3C trace context propagation** — so a span started in your Python service stays connected to the span on your Go consumer, across the async hop.
 
 The wedge: polyglot producers (any SQL client) + first-class OpenTelemetry, without the operational weight of Debezium/CDC.
 
+## 60-second quick start
+
+Requires Docker (or Podman with the compose plugin).
+
+```sh
+# 1. Start Postgres.
+docker compose up -d postgres
+
+# 2. Apply migrations.
+docker compose run --rm pgrelay migrate up
+
+# 3. Seed an outbox row pointed at any HTTP receiver
+# (replace example.invalid with your own URL to see deliveries).
+docker compose exec -T postgres psql -U pgrelay -d pgrelay <<'SQL'
+INSERT INTO pgrelay_outbox (aggregate_type, aggregate_id, event_type, payload, sink, destination)
+VALUES ('order', 'order-1', 'created', '{"id":"order-1"}'::jsonb, 'http', 'https://example.invalid/replace-me');
+SQL
+
+# 4. Run the dispatcher.
+docker compose up pgrelay
+```
+
+Health and metrics are exposed at `http://localhost:9090/{healthz,readyz,metrics}`.
+Configuration is via env vars — see [`internal/config/config.go`](./internal/config/config.go) for the full list.
+
 ## Roadmap
 
-- `v0.1.0-alpha` — HTTP sink, lease-based claim, retry/DLQ, PG 14–17 integration tests
-- `v0.2.0` — Kafka sink (franz-go), `pkg/tracectx` extract/inject helpers, embeddable Go API
+- `v0.2.0` — Kafka sink (franz-go), `pkg/tracectx` extract/inject helpers, embeddable Go API, dispatcher spans
 - `v0.3.0` — polyglot examples (Go + Python producers, mixed consumer), full docker-compose demo, Tempo trace screenshot
 - `v1.0.0` — k6 benchmarks, Grafana dashboard, multi-arch Docker image, launch
 

--- a/cmd/pgrelay/cli_integration_test.go
+++ b/cmd/pgrelay/cli_integration_test.go
@@ -33,13 +33,11 @@ func TestCLI_MigrateLifecycle(t *testing.T) {
 	dsn := pool.Config().ConnString()
 	env := []string{"PGRELAY_DATABASE_URL=" + dsn}
 
-	// status reflects the migrations testdb applied.
 	if res := runArgs(t, env, "migrate", "status"); res.err != nil ||
 		!strings.Contains(res.stdout, "version=") {
 		t.Fatalf("migrate status: err=%v stdout=%q stderr=%q", res.err, res.stdout, res.stderr)
 	}
 
-	// down without --yes must refuse — fat-finger guard.
 	res := runArgs(t, env, "migrate", "down")
 	if res.err == nil {
 		t.Fatalf("migrate down without --yes succeeded; want error\nstdout=%q", res.stdout)
@@ -48,13 +46,10 @@ func TestCLI_MigrateLifecycle(t *testing.T) {
 		t.Errorf("migrate down stderr = %q, want mention of --yes", res.stderr)
 	}
 
-	// down with --yes rolls back one step.
 	if res := runArgs(t, env, "migrate", "down", "--yes"); res.err != nil {
 		t.Fatalf("migrate down --yes: %v\nstderr: %s", res.err, res.stderr)
 	}
 
-	// up re-applies; idempotent on the second invocation (ErrNoChange
-	// is swallowed in migrateUpAction).
 	if res := runArgs(t, env, "migrate", "up"); res.err != nil {
 		t.Fatalf("migrate up: %v\nstderr: %s", res.err, res.stderr)
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: pgrelay
+      POSTGRES_PASSWORD: pgrelay
+      POSTGRES_DB: pgrelay
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U pgrelay -d pgrelay"]
+      interval: 1s
+      timeout: 3s
+      retries: 15
+
+  pgrelay:
+    build: .
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command: ["run"]
+    environment:
+      PGRELAY_DATABASE_URL: postgres://pgrelay:pgrelay@postgres:5432/pgrelay?sslmode=disable
+      PGRELAY_OPS_ADDR: ":9090"
+    ports:
+      - "9090:9090"

--- a/internal/outbox/dispatcher_integration_test.go
+++ b/internal/outbox/dispatcher_integration_test.go
@@ -175,7 +175,6 @@ func TestDispatcher_MaxAttemptsExhaustedGoesDead(t *testing.T) {
 	cfg.MaxAttempts = 2
 	f := startDispatcher(t, pool, cfg)
 
-	// Always retryable — dispatcher should give up after MaxAttempts.
 	f.Sink.SetOnSend(func(_ context.Context, _ sinks.Message) error {
 		return sinks.NewRetryableError(errors.New("503"), 0)
 	})
@@ -190,7 +189,6 @@ func TestDispatcher_MaxAttemptsExhaustedGoesDead(t *testing.T) {
 func TestDispatcher_RetryAfterIsFloor(t *testing.T) {
 	pool := testdb.New(t)
 	cfg := fastConfig()
-	// Make policy's NextDelay tiny so RetryAfter clearly wins.
 	cfg.RetryBase = time.Millisecond
 	cfg.RetryMax = 5 * time.Second
 	f := startDispatcher(t, pool, cfg)

--- a/internal/outbox/primitives_integration_test.go
+++ b/internal/outbox/primitives_integration_test.go
@@ -27,7 +27,6 @@ func TestClaim_HappyPath(t *testing.T) {
 	if rows[0].Attempts != 1 {
 		t.Errorf("Attempts = %d, want 1", rows[0].Attempts)
 	}
-	// Returned LeasedUntil must reflect the requested window.
 	if want := beforeClaim.Add(leaseDuration); rows[0].LeasedUntil.Before(want.Add(-time.Second)) {
 		t.Errorf("returned LeasedUntil = %s, want >= %s", rows[0].LeasedUntil, want)
 	}
@@ -42,8 +41,6 @@ func TestClaim_HappyPath(t *testing.T) {
 }
 
 func TestClaim_TieBreaksByID(t *testing.T) {
-	// Two rows with the same next_attempt_at must dispatch in id order
-	// per Claim's ORDER BY next_attempt_at, id.
 	pool := testdb.New(t)
 	at := time.Now().Add(-time.Second)
 	idLow := insertRow(t, pool, insertOpts{NextAttemptAt: at})
@@ -111,8 +108,6 @@ func TestClaim_SkipsLockedRows(t *testing.T) {
 	id1 := insertRow(t, pool, insertOpts{})
 	id2 := insertRow(t, pool, insertOpts{})
 
-	// Hold a row lock from a separate connection. The Claim's
-	// FOR UPDATE SKIP LOCKED must pass this row over to id2.
 	tx, err := pool.Begin(t.Context())
 	if err != nil {
 		t.Fatalf("Begin: %v", err)

--- a/internal/outbox/sinks/http.go
+++ b/internal/outbox/sinks/http.go
@@ -16,6 +16,11 @@ import (
 // retryable (408 / 425 / 429 / 5xx + network errors) and terminal
 // (everything else, including malformed destinations and 3xx); the
 // dispatcher (#6) owns the retry policy and surfaces metrics.
+//
+// Trust boundary: any caller with INSERT on pgrelay_outbox controls
+// row.destination, and pgrelay will POST to that URL from the
+// dispatcher's network — restrict INSERT to trusted producers or this
+// becomes an SSRF pivot inside the cluster.
 type HTTPSink struct {
 	client *http.Client
 }

--- a/internal/outbox/sinks/http_test.go
+++ b/internal/outbox/sinks/http_test.go
@@ -124,7 +124,6 @@ func TestHTTPSink_UserHeadersCannotOverwriteReserved(t *testing.T) {
 		t.Fatalf("Send: %v", err)
 	}
 
-	// Reserved still set by sink.
 	if got := seen.Get("Content-Type"); got != "application/json" {
 		t.Errorf("Content-Type = %q, user header leaked through", got)
 	}
@@ -137,7 +136,6 @@ func TestHTTPSink_UserHeadersCannotOverwriteReserved(t *testing.T) {
 	if got := seen.Get("Tracestate"); got != "ts-real" {
 		t.Errorf("Tracestate = %q, user header leaked through", got)
 	}
-	// Custom user headers passed through unchanged.
 	if got := seen.Get("X-Custom-Header"); got != "kept" {
 		t.Errorf("X-Custom-Header = %q, want kept", got)
 	}

--- a/internal/outbox/sinks/sinkmock/mock_test.go
+++ b/internal/outbox/sinks/sinkmock/mock_test.go
@@ -56,7 +56,7 @@ func TestSink_EnqueueErrorsConsumesInOrder(t *testing.T) {
 		results[i] = m.Send(t.Context(), sinks.Message{ID: int64(i)})
 	}
 
-	wants := []error{boom, nil, boom, nil} // 4th call: queue exhausted, returns nil
+	wants := []error{boom, nil, boom, nil}
 	for i, want := range wants {
 		if !errors.Is(results[i], want) {
 			t.Errorf("Send[%d] = %v, want %v", i, results[i], want)
@@ -68,7 +68,7 @@ func TestSink_EnqueueErrorsAppends(t *testing.T) {
 	a, b := errors.New("a"), errors.New("b")
 	m := sinkmock.New("")
 	m.EnqueueErrors(a)
-	m.EnqueueErrors(b) // appends, doesn't replace
+	m.EnqueueErrors(b)
 
 	results := []error{
 		m.Send(t.Context(), sinks.Message{ID: 1}),
@@ -81,7 +81,7 @@ func TestSink_EnqueueErrorsAppends(t *testing.T) {
 
 func TestSink_OnSendCallbackTakesPrecedence(t *testing.T) {
 	m := sinkmock.New("")
-	m.EnqueueErrors(errors.New("queued")) // would fire if callback wasn't set
+	m.EnqueueErrors(errors.New("queued"))
 
 	called := 0
 	m.SetOnSend(func(_ context.Context, msg sinks.Message) error {
@@ -161,7 +161,6 @@ func TestSink_ConcurrentSendsAreSafe(t *testing.T) {
 		t.Fatalf("Sent len = %d, want %d", len(sent), total)
 	}
 
-	// Assert no message was lost or duplicated under contention.
 	got := make([]int64, len(sent))
 	for i, msg := range sent {
 		got[i] = msg.ID

--- a/internal/outbox/state_collector_integration_test.go
+++ b/internal/outbox/state_collector_integration_test.go
@@ -35,7 +35,6 @@ func TestStateCollector_CountsAndBacklog(t *testing.T) {
 	// assertion has comfortable headroom over container clock jitter.
 	insertRow(t, pool, insertOpts{Status: "pending", NextAttemptAt: time.Now().Add(-10 * time.Minute)})
 	insertRow(t, pool, insertOpts{Status: "pending", NextAttemptAt: time.Now().Add(-5 * time.Second)})
-	// Future pending must NOT count toward backlog.
 	insertRow(t, pool, insertOpts{Status: "pending", NextAttemptAt: time.Now().Add(time.Hour)})
 
 	insertRow(t, pool, insertOpts{

--- a/internal/pgconn/pgconn.go
+++ b/internal/pgconn/pgconn.go
@@ -59,9 +59,6 @@ func (c Config) Validate() error {
 // a second call with the same reg fails with AlreadyRegisteredError.
 // For multiple pools, wrap reg with prometheus.WrapRegistererWith so
 // each pool's metrics carry distinguishing labels.
-//
-// Future commits will add OTel tracing on the same ConnConfig.Tracer
-// hook — composition will require pgx.MultiTracer.
 func New(ctx context.Context, cfg Config, reg prometheus.Registerer) (pool *pgxpool.Pool, err error) {
 	if err = cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("validate pgconn config: %w", err)

--- a/migrations/0001_outbox.up.sql
+++ b/migrations/0001_outbox.up.sql
@@ -5,10 +5,9 @@
 -- ORDERING CAVEAT: BIGSERIAL is monotonic per-connection but NOT per-commit.
 -- Two concurrent producers writing to the same aggregate can commit out of
 -- id order; readers ORDER BY id may then dispatch the later-committed row
--- first. This is acceptable for v0.1.0-alpha (per-aggregate ordering is
--- post-Week-2 per the plan). Resolve before per-aggregate ordering ships:
--- typical fix is a (aggregate_id, seq BIGINT) populated under a transactional
--- advisory lock, or an xact_id snapshot via pg_current_xact_id() (PG 13+).
+-- first. Acceptable for v0.1.0-alpha — revisit when per-aggregate ordering
+-- is added. Typical fix: (aggregate_id, seq BIGINT) populated under a
+-- transactional advisory lock, or xact_id via pg_current_xact_id() (PG 13+).
 --
 -- DEFERRED: a standalone (status) index for ad-hoc operator triage queries.
 -- Outbox is a work queue with retention, not a log table — partial indexes


### PR DESCRIPTION
Closes #8 (pre-release polish portion). After merge the next steps are tag, multi-arch Docker build via release workflow, and GitHub Release draft from the CHANGELOG body.

## Pre-release polish

- `docs(sinks): note SSRF trust boundary on HTTPSink` — godoc spells out that anyone with INSERT on `pgrelay_outbox` controls `row.destination`, and that pgrelay will POST to that URL from the dispatcher's network.
- `chore(pgconn): drop future-roadmap comment` — removed `pgconn.go` mention of "future commits will add OTel tracing"; v0.2 work belongs in the tracker, not in v0.1 source.
- `docs(migrations): rephrase ORDERING CAVEAT for post-release readers` — replaced "post-Week-2 per the plan" phrasing with version-stable wording. Migrations ship to operators forever and shouldn't reference internal week numbers.
- `chore: drop redundant test comments` — ~15 step-narration comments removed from test files. The test names already carried the information.
- `docs(readme): v0.1.0-alpha status and 60-second quick start` — README status flipped from "🚧 Under construction" to the shipped feature list. Added a `docker compose`-based 60-second quick start (postgres + pgrelay services in a new `docker-compose.yml`).
- `docs: CHANGELOG.md v0.1.0-alpha section` — new CHANGELOG following Keep-a-Changelog with `Added` and `Known Limitations` subsections; reused as the GitHub Release body at tag time.

## Out of scope

- Multi-arch Docker build pipeline — separate PR landing the release workflow before tagging.
- Full polyglot README — Week 3 per the original plan; the alpha quickstart is the smoke-test version only.
- Architectural follow-ups raised in the pre-release audit (dispatcher OTel spans, `outbox` → `internal/config` decoupling, DB-level payload `CHECK`) — all tracked for v0.2.0.

## Verification

- `make build / test / lint / vuln` — green locally with Go 1.25.10.
- Quick-start commands match the shipped CLI surface and migration schema.
- CI on this PR: `floor`, `golangci-lint`, `govulncheck`, `unit (1.25)`, `integration (14/15/16/17)`.