### PR TITLE
chore: post-audit polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Configuration is via env vars — see [`internal/config/config.go`](./internal/c
 ## Roadmap
 
 - `v0.2.0` — Kafka sink (franz-go), `pkg/tracectx` extract/inject helpers, embeddable Go API, dispatcher spans
-- `v0.3.0` — polyglot examples (Go + Python producers, mixed consumer), full docker-compose demo, Tempo trace screenshot
+- `v0.3.0` — polyglot examples (Go + Python producers, mixed consumer), Tempo/Jaeger demo compose, trace screenshot
 - `v1.0.0` — k6 benchmarks, Grafana dashboard, multi-arch Docker image, launch
 
 ## License

--- a/cmd/pgrelay/integration_helpers_test.go
+++ b/cmd/pgrelay/integration_helpers_test.go
@@ -89,8 +89,8 @@ const runArgsTimeout = 30 * time.Second
 func runArgs(t testing.TB, envOverrides []string, args ...string) cmdResult {
 	t.Helper()
 	// Resolve the binary outside the timeout — the first caller pays
-	// the `go build -race` cost (~30s cold), and that's compile time,
-	// not subcommand runtime.
+	// the `go build` cost (seconds on cold cache), and that's compile
+	// time, not subcommand runtime.
 	bin := buildBinary(t)
 
 	ctx, cancel := context.WithTimeout(t.Context(), runArgsTimeout)

--- a/cmd/pgrelay/main.go
+++ b/cmd/pgrelay/main.go
@@ -25,8 +25,8 @@ func main() {
 	}
 }
 
-// dispatch returns instead of calling os.Exit so deferred cleanup (signal
-// notify, future OTel flush) actually runs on error paths.
+// dispatch returns instead of calling os.Exit so deferred cleanup (OTel
+// flush, signal notify) actually runs on error paths.
 func dispatch() error {
 	// SIGINT/SIGTERM cancellation flows into long-running subcommands
 	// (run, migrate) via the cli ctx; short ones (version) ignore it.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_PASSWORD: pgrelay
       POSTGRES_DB: pgrelay
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U pgrelay -d pgrelay"]
       interval: 1s
@@ -23,4 +23,4 @@ services:
       PGRELAY_DATABASE_URL: postgres://pgrelay:pgrelay@postgres:5432/pgrelay?sslmode=disable
       PGRELAY_OPS_ADDR: ":9090"
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"


### PR DESCRIPTION
Four small drifts surfaced in the round-2 pre-release audit:

- `cmd/pgrelay/main.go:29` — comment said "future OTel flush"; flush is already wired in `run.go`. Rephrased.
- `cmd/pgrelay/integration_helpers_test.go:92` — comment mentioned a `go build -race` cost, but the build line has no `-race` flag. Rephrased.
- `README.md` v0.3.0 roadmap — "full docker-compose demo" overlaps with the quick-start compose that already ships. Reworded to "Tempo/Jaeger demo compose, trace screenshot".
- `docker-compose.yml` — Postgres (5432) and ops (9090) bound to `0.0.0.0` on the host. For a local-dev quick-start, `127.0.0.1` is safer and prevents accidental LAN exposure on misconfigured firewalls.

## Verification

- `make build / test / lint / vuln` — green locally with Go 1.25.10.
- CI on this PR: `floor`, `golangci-lint`, `govulncheck`, `unit (1.25)`, `integration (14/15/16/17)`.