### PR TITLE
ci(release): filter download-artifact and align commit SHA across builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,9 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+      - name: Short SHA
+        id: sha
+        run: echo "short=${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
       - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
@@ -81,9 +84,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Short SHA matches the tarball build's COMMIT so both
+          # artifacts report the same `pgrelay version` string.
           build-args: |
             VERSION=${{ steps.meta.outputs.version }}
-            COMMIT=${{ github.sha }}
+            COMMIT=${{ steps.sha.outputs.short }}
 
   release:
     needs: [binaries, docker]
@@ -92,6 +97,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
         with:
+          # docker/build-push-action v6 auto-uploads a `<repo>.dockerbuild`
+          # build-summary artifact; filter to the binary tarballs only.
+          pattern: bin-*
           path: artifacts
           merge-multiple: true
       - name: Extract CHANGELOG section


### PR DESCRIPTION
Two issues surfaced when the v0.1.0-alpha release workflow ran:

1. **Release job failed at `actions/download-artifact@v4`.** With no `pattern:` filter, the step downloads every artifact in the run, including `docker/build-push-action@v6`'s auto-uploaded `<repo>.dockerbuild` build-summary artifact. Download of that aux artifact failed retries and tanked the whole job. Tar binaries + multi-arch image had already published successfully; only the GitHub Release publish step was lost. The current v0.1.0-alpha release was created manually from the workflow's binary artifacts.

   Fix: filter to `pattern: bin-*` so the release job only pulls the binary tarballs.

2. **Commit-SHA drift between Docker and tarball binaries.** The tarball matrix passed `COMMIT=${GITHUB_SHA:0:7}` (7-char short SHA); the Docker build passed `COMMIT=${{ github.sha }}` (full 40-char SHA). So `pgrelay version` reported a different string depending on which artifact the user grabbed.

   Fix: add a short-SHA prep step in the Docker job and pass `COMMIT=${{ steps.sha.outputs.short }}` so both builds produce the same `pgrelay 0.1.0-alpha (commit abcdef1, go1.26.x)` string.

## Verification

- Both fixes are documented inline with WHY comments.
- Real test fires on next `v*` tag push.